### PR TITLE
Fetch EMT dashboard update date from Google Sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,9 +805,6 @@
     });
     // Initialize dashboard
     function initDashboard() {
-        // Set current date
-        document.getElementById('currentDate').textContent = `Data as of ${new Date().toLocaleDateString()}`;
-
         // Generate dynamic components
         generateKPICards();
         generateCurrencyDistribution();


### PR DESCRIPTION
## Summary
- pull last update date from dedicated Google Sheet CSV
- replace both header and footer dates during dashboard generation
- remove client-side date override so HTML retains fetched date
- fix CSV export URL for snapshot date sheet

## Testing
- `node update-data.js` *(fails: connect ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_b_68adcc7223c8832f939b3c4de73b4769