### PR TITLE
Display long-form update date consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This project tracks issuers of Electronic Money Tokens (EMTs) under the MiCAR fr
 
 `update-data.js` downloads a CSV export of the ESMA EMT register from Google Sheets.
 
-The script parses the CSV, converts each row into a JavaScript object and then rewrites `index.html` with the new data and an updated source date.
+The script parses the CSV, converts each row into a JavaScript object and then rewrites `index.html` with the new data and a human‑friendly source date.

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
     <div>
     <h1 class="text-4xl font-bold text-white mb-1">MiCAR EMT License Tracker</h1>
     <p class="text-blue-100 text-lg additional-info">Electronic Money Token Issuers Analytics</p>
-    <p class="text-blue-200 text-sm mt-1 additional-info">Source: ESMA EMT Register, 7 December 2025</p>
+    <p class="text-blue-200 text-sm mt-1 additional-info">Source: ESMA EMT Register, 12 July 2025</p>
     </div>
     </div>
     <div class="flex space-x-3">
@@ -328,7 +328,7 @@
             MiCAR EMT License Tracker – Electronic Money Token Regulatory Overview
           </p>
           <p class="text-gray-400 text-sm mt-2" id="currentDate">
-            Data as of 2025/07/12
+            Data as of 12 July 2025
           </p>
         </div>
 

--- a/update-data.js
+++ b/update-data.js
@@ -64,17 +64,34 @@ function extractDateFromCsv(csv) {
 function formatDate(dateStr) {
     if (!dateStr) {
         const today = new Date();
+        const longDate = today.toLocaleDateString('en-GB', {
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric'
+        });
         return {
-            longDate: today.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }),
-            shortDate: today.toLocaleDateString('en-GB')
+            longDate,
+            shortDate: longDate
         };
     }
 
-    const [day, month, year] = dateStr.split(/[\/\-]/);
+    const parts = dateStr.split(/[\/\-]/);
+    let day, month, year;
+    if (parts[0].length === 4) {
+        [year, month, day] = parts; // Format: YYYY-MM-DD
+    } else {
+        [day, month, year] = parts; // Format: DD-MM-YYYY or DD/MM/YYYY
+    }
+
     const dateObj = new Date(`${year}-${month}-${day}`);
+    const longDate = dateObj.toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric'
+    });
     return {
-        longDate: dateObj.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }),
-        shortDate: `${day.padStart(2, '0')}/${month.padStart(2, '0')}/${year}`
+        longDate,
+        shortDate: longDate
     };
 }
 
@@ -161,10 +178,10 @@ function updateHtmlFile(newData, lastUpdated) {
     const newDataString = `${dataPattern}${JSON.stringify(newData, null, 4)};`;
     const updatedHtml = htmlContent.substring(0, dataStart) + newDataString + htmlContent.substring(dataEnd);
 
-    const { longDate, shortDate } = formatDate(lastUpdated);
+    const { longDate } = formatDate(lastUpdated);
     const updatedHtmlWithDate = updatedHtml
         .replace(/Source: ESMA EMT Register, \d{1,2} \w+ \d{4}/, `Source: ESMA EMT Register, ${longDate}`)
-        .replace(/Data as of \d{1,2}\/\d{1,2}\/\d{4}/, `Data as of ${shortDate}`);
+        .replace(/Data as of [^<]+/, `Data as of ${longDate}`);
 
     fs.writeFileSync(htmlFile, updatedHtmlWithDate);
     console.log('✅ Dashboard updated successfully!');


### PR DESCRIPTION
## Summary
- parse ISO and local date formats and render a long-form date for display
- replace both "Source" and "Data as of" lines with the unified long-form date
- document the long-form date update in the README

## Testing
- `node --check update-data.js`
- `node update-data.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68add427be8c832f8490e1d70865c159