### PR TITLE
refactor: use native fetch with env-configured URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ This project tracks issuers of Electronic Money Tokens (EMTs) under the MiCAR fr
 `update-data.js` downloads a CSV export of the ESMA EMT register from Google Sheets.
 
 The script parses the CSV, converts each row into a JavaScript object and then rewrites `index.html` with the new data and a human‑friendly source date.
+
+## Configuration
+
+The script reads CSV locations from the `CSV_URL` and `DATE_URL` environment variables. If they are not set, default URLs pointing to the public Google Sheet are used.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,8 @@
+const DEFAULT_CSV_URL = 'https://docs.google.com/spreadsheets/d/1RfeiT68rH65izevXw_Upqdn0lXz-IGI83Zn3q0SBEbE/export?format=csv&id=1RfeiT68rH65izevXw_Upqdn0lXz-IGI83Zn3q0SBEbE&gid=0';
+const DEFAULT_DATE_URL = 'https://docs.google.com/spreadsheets/d/1RfeiT68rH65izevXw_Upqdn0lXz-IGI83Zn3q0SBEbE/export?format=csv&gid=353293525';
+
+module.exports = {
+    csvUrl: process.env.CSV_URL || DEFAULT_CSV_URL,
+    dateUrl: process.env.DATE_URL || DEFAULT_DATE_URL
+};
+


### PR DESCRIPTION
## Summary
- read CSV and date URLs from new `CSV_URL` and `DATE_URL` env vars via a config helper
- replace custom redirect logic with Node's built-in `fetch`
- document configuration in README

## Testing
- `CSV_URL='data:text/csv;base64,IyxJc3N1ZXIgKEhRKSxIb21lIFN0YXRlLENvbXBldGVudCBBdXRob3JpdHksQXV0aG9yaXNlZCBFTVQocyksVG9rZW5zLEV1cm8sVVNELEdCUCxDWksKMSxUZXN0IElzc3VlcixTdGF0ZSxBdXRob3JpdHksVG9rZW4sMTAsNSwzLDEsMgo=' DATE_URL='data:text/csv;base64,QSxCCjEsMjAyNC0wMS0wMQo=' node update-data.js`

------
https://chatgpt.com/codex/tasks/task_b_68addd6b28f0832fb37c75144b6e066c