### PR TITLE
Add GitHub Pages workflow for previews

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+name: Pages: Build & Deploy (Prod + PR Previews)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # OPTIONAL: Node build (skip if you serve raw HTML/CSS/JS from repo root)
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Install only if package-lock.json exists
+      - name: Install deps (if present)
+        if: hashFiles('**/package-lock.json') != ''
+        run: npm ci
+
+      - name: Build (if present)
+        run: npm run build --if-present
+
+      # Upload the site artifact for Pages to deploy
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./  # publish repo root
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy GitHub Pages for both main and PR previews

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0de2b454832fa8063f924ae7cfab