### PR TITLE
Allow workflow to pass sheet URLs via env

### DIFF
--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -27,6 +27,10 @@ jobs:
         node-version: '18'
 
     - name: Update dashboard data
+      env:
+        CSV_URL: ${{ vars.CSV_URL || secrets.CSV_URL || '' }}
+        DATE_URL: ${{ vars.DATE_URL || secrets.DATE_URL || '' }}
+        NON_COMPLIANT_URL: ${{ vars.NON_COMPLIANT_URL || secrets.NON_COMPLIANT_URL || '' }}
       run: |
         echo "🔄 Starting dashboard update..."
         node update-data.js

--- a/config.js
+++ b/config.js
@@ -1,8 +1,10 @@
 const DEFAULT_CSV_URL = 'https://docs.google.com/spreadsheets/d/1RfeiT68rH65izevXw_Upqdn0lXz-IGI83Zn3q0SBEbE/export?format=csv&id=1RfeiT68rH65izevXw_Upqdn0lXz-IGI83Zn3q0SBEbE&gid=0';
 const DEFAULT_DATE_URL = 'https://docs.google.com/spreadsheets/d/1RfeiT68rH65izevXw_Upqdn0lXz-IGI83Zn3q0SBEbE/export?format=csv&gid=353293525';
+const DEFAULT_NON_COMPLIANT_URL = 'https://docs.google.com/spreadsheets/d/1RfeiT68rH65izevXw_Upqdn0lXz-IGI83Zn3q0SBEbE/export?format=csv&gid=409089345';
 
 module.exports = {
     csvUrl: process.env.CSV_URL || DEFAULT_CSV_URL,
-    dateUrl: process.env.DATE_URL || DEFAULT_DATE_URL
+    dateUrl: process.env.DATE_URL || DEFAULT_DATE_URL,
+    nonCompliantUrl: process.env.NON_COMPLIANT_URL || DEFAULT_NON_COMPLIANT_URL
 };
 

--- a/index.html
+++ b/index.html
@@ -629,50 +629,561 @@
 
     // Non-compliant entities data
     const nonCompliantData = [
-        { id: 1, entity: "Dobibo", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://dobibo.com", "https://dobibo1.com", "https://dobibo2.com"] },
-        { id: 2, entity: "Fameexn", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://fameexn.top", "https://fameexn.com"] },
-        { id: 3, entity: "Spazio Finanziario", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["www.spaziofinanziario.com"] },
-        { id: 4, entity: "HTXcoin-az", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://m.htxcoin-az.com"] },
-        { id: 5, entity: "Stock Credit Wallet", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://stockcreditwallet.com"] },
-        { id: 6, entity: "Paycraftv.top - Paycraftn.top", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://paycraftv.top", "https://paycraftn.top"] },
-        { id: 7, entity: "CoinBank Exchange", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://coinbankexchange.icu"] },
-        { id: 8, entity: "AKQ", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://akqa715.it", "https://AKQ1181.it"] },
-        { id: 9, entity: "Fameexn", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://fameexe.top", "https://fameexj.top"] },
-        { id: 10, entity: "ArgonInternational", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://argonintgroup.com", "https://cfd.argonintgroup.com"] },
-        { id: 11, entity: "Deroka UAB", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://dtcoin.tech", "https://dtwallet.io", "https://forcedmarketcap.tech"] },
-        { id: 12, entity: "DTSocialize Holding PLC", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://dtsmoney.com", "https://portal.dtsmoney.com"] },
-        { id: 13, entity: "Caa871", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://caa871.it"] },
-        { id: 14, entity: "Sdf837", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://sdf837.it"] },
-        { id: 15, entity: "SYBZ", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://sybzgroup.co"] },
-        { id: 16, entity: "Egplus.vip", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://egplus.vip"] },
-        { id: 17, entity: "Egalite.bond", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://egalite.bond"] },
-        { id: 18, entity: "Arbismart UAB", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://arbismart.com", "https://dashboard.arbismart.com"] },
-        { id: 19, entity: "Blockbyteq", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://blockbyteq.top"] },
-        { id: 20, entity: "Bvoxed", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://bvoxed.com"] },
-        { id: 21, entity: "BeratCoin", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://btc6688.com"] },
-        { id: 22, entity: "Interersos-Interesosf", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://interersosf.org", "https://interersos.org"] },
-        { id: 23, entity: "Cfw896", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://cfw896.it"] },
-        { id: 24, entity: "Lumex", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://stratoslumex.com", "https://stratoslumex.net"] },
-        { id: 25, entity: "Tmxa", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://60yg.com"] },
-        { id: 26, entity: "Uyr968|Fwq367", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://uyr968.it", "https://fwq367.it"] },
-        { id: 27, entity: "Syk755", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["www.syk755.it"] },
-        { id: 28, entity: "Pxm266", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://pxm266.it"] },
-        { id: 29, entity: "Hct685", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://hct685.it"] },
-        { id: 30, entity: "Sdh878", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://sdh878.it"] },
-        { id: 31, entity: "Skillnexp", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://skillnexp.top"] },
-        { id: 32, entity: "Ymg686", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://ymg686.it"] },
-        { id: 33, entity: "LWEX", country: "Slovakia", authority: "National Bank of Slovakia (NBS)", websites: ["https://lwex.com/"] },
-        { id: 34, entity: "Coingridr.top", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://coingridr.top"] },
-        { id: 35, entity: "Gigtaskr", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://gigtaskr.top"] },
-        { id: 36, entity: "Sxr922", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://sxr922.it"] },
-        { id: 37, entity: "09pqws", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://09pqws.it"] },
-        { id: 38, entity: "DSS776", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://dss776.it"] },
-        { id: 39, entity: "ERY357", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://ery357.it"] },
-        { id: 40, entity: "TNT882", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://tnt882.it"] },
-        { id: 41, entity: "ZeroTrillionWorld", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://zerotrillionworld.it"] },
-        { id: 42, entity: "ZGV796", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://zgv796.it"] },
-        { id: 43, entity: "78DEF", country: "Italy", authority: "Commissione Nazionale per le Societa e la Borsa (CONSOB)", websites: ["https://78def.it"] }
-    ];
+    {
+        "id": 1,
+        "entity": "Dobibo",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://dobibo.com",
+            "https://dobibo1.com",
+            "https://dobibo2.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 2,
+        "entity": "Fameexn",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://fameexn.top",
+            "https://fameexn.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 3,
+        "entity": "Spazio Finanziario",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "www.spaziofinanziario.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 4,
+        "entity": "HTXcoin-az",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://m.htxcoin-az.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 5,
+        "entity": "Stock Credit Wallet",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://stockcreditwallet.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 6,
+        "entity": "Paycraftv.top - Paycraftn.top",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://paycraftv.top",
+            "https://paycraftn.top"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 7,
+        "entity": "CoinBank Exchange",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://coinbankexchange.icu"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 8,
+        "entity": "AKQ",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://akqa715.it",
+            "https://AKQ1181.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 9,
+        "entity": "Fameexn",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://fameexe.top",
+            "https://fameexj.top"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 10,
+        "entity": "ArgonInternational",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://argonintgroup.com",
+            "https://cfd.argonintgroup.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 11,
+        "entity": "Deroka UAB",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://dtcoin.tech",
+            "https://dtwallet.io",
+            "https://forcedmarketcap.tech"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 12,
+        "entity": "DTSocialize Holding PLC",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://dtsmoney.com",
+            "https://portal.dtsmoney.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 13,
+        "entity": "Caa871",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://caa871.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 14,
+        "entity": "Sdf837",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://sdf837.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 15,
+        "entity": "SYBZ",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://sybzgroup.co"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 16,
+        "entity": "Egplus.vip",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://egplus.vip"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 17,
+        "entity": "Egalite.bond",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://egalite.bond"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 18,
+        "entity": "Arbismart UAB",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://arbismart.com",
+            "https://dashboard.arbismart.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 19,
+        "entity": "Blockbyteq",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://blockbyteq.top"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 20,
+        "entity": "Bvoxed",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://bvoxed.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 21,
+        "entity": "BeratCoin",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://btc6688.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 22,
+        "entity": "Interersos-Interesosf",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://interersosf.org",
+            "https://interersos.org"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 23,
+        "entity": "Cfw896",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://cfw896.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 24,
+        "entity": "Lumex",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://stratoslumex.com",
+            "https://stratoslumex.net"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 25,
+        "entity": "Tmxa",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://60yg.com"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 26,
+        "entity": "Uyr968|Fwq367",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://uyr968.it",
+            "https://fwq367.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 27,
+        "entity": "Syk755",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "www.syk755.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 28,
+        "entity": "Pxm266",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://pxm266.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 29,
+        "entity": "Hct685",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://hct685.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 30,
+        "entity": "Sdh878",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://sdh878.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 31,
+        "entity": "Skillnexp",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://skillnexp.top"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 32,
+        "entity": "Ymg686",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://ymg686.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 33,
+        "entity": "LWEX",
+        "country": "Slovakia",
+        "authority": "National Bank of Slovakia (NBS)",
+        "websites": [
+            "https://lwex.com/"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 34,
+        "entity": "Coingridr.top",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://coingridr.top"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 35,
+        "entity": "Gigtaskr",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://gigtaskr.top"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 36,
+        "entity": "Sxr922",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://sxr922.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 37,
+        "entity": "09pqws",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://09pqws.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 38,
+        "entity": "DSS776",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://dss776.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 39,
+        "entity": "ERY357",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://ery357.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 40,
+        "entity": "TNT882",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://tnt882.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 41,
+        "entity": "ZeroTrillionWorld",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://zerotrillionworld.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 42,
+        "entity": "ZGV796",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://zgv796.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 43,
+        "entity": "78DEF",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://78def.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 44,
+        "entity": "Atomic Wallet",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://atomicwallet.io"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 45,
+        "entity": "Cexrqw.com",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://cexrqw.com"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 46,
+        "entity": "Interersos.it",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://interersos.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 47,
+        "entity": "YUI236",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://yui236.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 48,
+        "entity": "DRST78",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://drst78.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 49,
+        "entity": "GDY733",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://gdy733.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 50,
+        "entity": "XUR652",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://xur652.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 51,
+        "entity": "YZA335",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://yza335.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 52,
+        "entity": "BHP536",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://bhp536.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 53,
+        "entity": "MJU567",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://mju567.it"
+        ],
+        "isNew": true
+    },
+    {
+        "id": 54,
+        "entity": "TNT788",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "https://tnt788.it"
+        ],
+        "isNew": true
+    }
+];
 
     let filteredData = [...data];
     let filteredNonCompliantData = [...nonCompliantData];
@@ -929,7 +1440,14 @@
         tbody.innerHTML = dataToShow.map((item, index) => `
             <tr class="border-b hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 transition-all duration-200 ${index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}">
                 <td class="p-4">
-                    <div class="font-semibold text-gray-800">${item.entity}</div>
+                    <div class="font-semibold text-gray-800 flex items-center">
+                        <span>${item.entity}</span>
+                        ${item.isNew ? `
+                            <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold text-blue-700 bg-blue-100">
+                                <i class="fas fa-star text-blue-500 mr-1"></i>New
+                            </span>
+                        ` : ''}
+                    </div>
                 </td>
                 <td class="p-4">
                     <span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-medium">
@@ -947,8 +1465,9 @@
                     </div>
                 </td>
                 <td class="p-4 text-center">
-                    <span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-bold">
-                        <i class="fas fa-exclamation-triangle mr-1"></i>Flagged
+                    <span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-bold" title="Flagged">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <span class="sr-only">Flagged</span>
                     </span>
                 </td>
             </tr>

--- a/update-data.js
+++ b/update-data.js
@@ -355,11 +355,8 @@ async function main() {
         console.log('📋 First 200 characters:', data.substring(0, 200));
 
         // Final check if we still got HTML
-        if (data.includes('<HTML>') || data.includes('<html>') || data.includes('Temporary Redirect')) {
-            console.error('❌ Still receiving HTML after redirect handling!');
-            console.error('📋 Raw response:', data.substring(0, 500));
-            process.exit(1);
-        }
+        ensureCsvResponseValid(data, 'issuer feed');
+        ensureCsvResponseValid(nonCompliantCsv, 'non-compliant feed');
 
         const csvArray = csvToArray(data);
         console.log('📊 Parsed', csvArray.length, 'valid rows');
@@ -384,6 +381,14 @@ async function main() {
         updateHtmlFile(jsData, sheetDate, nonCompliantEntries);
     } catch (error) {
         console.error('❌ Error fetching CSV:', error);
+        process.exit(1);
+    }
+}
+
+function ensureCsvResponseValid(csvText, label) {
+    if (!csvText || /<html|<HTML|Temporary Redirect/i.test(csvText)) {
+        console.error(`❌ ${label} returned unexpected HTML or empty content.`);
+        console.error('📋 Raw response preview:', (csvText || '').substring(0, 500));
         process.exit(1);
     }
 }

--- a/update-data.js
+++ b/update-data.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { csvUrl, dateUrl } = require('./config');
+const { csvUrl, dateUrl, nonCompliantUrl } = require('./config');
 
 function csvToArray(str, delimiter = ',') {
     const lines = str.split('\n');
@@ -18,6 +18,25 @@ function csvToArray(str, delimiter = ',') {
     }
 
     return result.filter(row => row['#'] && row['#'] !== '' && row['#'] !== 'nan' && !isNaN(parseInt(row['#'])));
+}
+
+function csvToArrayGeneric(str) {
+    const lines = str.split('\n');
+    const headers = parseCSVLine(lines[0]);
+    const result = [];
+
+    for (let i = 1; i < lines.length; i++) {
+        if (lines[i].trim()) {
+            const values = parseCSVLine(lines[i]);
+            const obj = {};
+            headers.forEach((header, index) => {
+                obj[header.trim()] = values[index] ? values[index].trim() : '';
+            });
+            result.push(obj);
+        }
+    }
+
+    return result;
 }
 
 function parseCSVLine(line) {
@@ -141,7 +160,99 @@ function convertToJsData(csvData) {
     return data;
 }
 
-function updateHtmlFile(newData, lastUpdated) {
+const memberStateMap = {
+    'AT': 'Austria',
+    'BE': 'Belgium',
+    'BG': 'Bulgaria',
+    'HR': 'Croatia',
+    'CY': 'Cyprus',
+    'CZ': 'Czech Republic',
+    'DK': 'Denmark',
+    'EE': 'Estonia',
+    'FI': 'Finland',
+    'FR': 'France',
+    'DE': 'Germany',
+    'GR': 'Greece',
+    'HU': 'Hungary',
+    'IE': 'Ireland',
+    'IT': 'Italy',
+    'LV': 'Latvia',
+    'LT': 'Lithuania',
+    'LU': 'Luxembourg',
+    'MT': 'Malta',
+    'NL': 'Netherlands',
+    'PL': 'Poland',
+    'PT': 'Portugal',
+    'RO': 'Romania',
+    'SK': 'Slovakia',
+    'SI': 'Slovenia',
+    'ES': 'Spain',
+    'SE': 'Sweden',
+    'IS': 'Iceland',
+    'LI': 'Liechtenstein',
+    'NO': 'Norway',
+    'UK': 'United Kingdom'
+};
+
+function mapMemberState(code) {
+    if (!code) return '';
+    const trimmed = code.trim();
+    return memberStateMap[trimmed.toUpperCase()] || trimmed;
+}
+
+function convertToNonCompliantData(csvData) {
+    const entries = [];
+    const entryIndexByKey = new Map();
+
+    csvData.forEach((row, index) => {
+        const entity = row['Commercial Name'] || '';
+        const authority = row['Competent Authority'] || '';
+        const memberState = mapMemberState(row['Member State'] || '');
+        const websites = (row['ae_website'] || '')
+            .split('|')
+            .map(site => site.trim())
+            .filter(site => site.length > 0);
+        const isNew = (row['Column 1'] || '').toLowerCase() === 'new';
+
+        if (!entity) {
+            return;
+        }
+
+        const dedupeKey = `${entity}::${memberState}::${websites.join('|')}`;
+        if (entryIndexByKey.has(dedupeKey)) {
+            const existingIndex = entryIndexByKey.get(dedupeKey);
+            const existingEntry = entries[existingIndex];
+            if (isNew && !existingEntry.isNew) {
+                existingEntry.isNew = true;
+                console.log('🔄 Updated existing non-compliant entry to NEW status:', entity);
+            }
+            return;
+        }
+
+        entryIndexByKey.set(dedupeKey, entries.length);
+
+        entries.push({
+            id: entries.length + 1,
+            entity,
+            country: memberState,
+            authority,
+            websites,
+            isNew
+        });
+
+        console.log('🚨 Non-compliant entity added:', {
+            entity,
+            country: memberState,
+            authority,
+            websites,
+            isNew
+        });
+    });
+
+    return entries;
+}
+
+function updateHtmlFile(newData, lastUpdated, nonCompliantEntries) {
     const htmlFile = 'index.html';
 
     if (!fs.existsSync(htmlFile)) {
@@ -188,8 +299,19 @@ function updateHtmlFile(newData, lastUpdated) {
     const newDataString = `${dataPattern}${JSON.stringify(newData, null, 4)};`;
     const updatedHtml = htmlContent.substring(0, dataStart) + newDataString + htmlContent.substring(dataEnd);
 
+    const nonCompliantStart = updatedHtml.indexOf('const nonCompliantData = [');
+    let finalHtml = updatedHtml;
+
+    if (nonCompliantStart !== -1) {
+        const nonCompliantEnd = updatedHtml.indexOf('];', nonCompliantStart) + 2;
+        const nonCompliantString = `const nonCompliantData = ${JSON.stringify(nonCompliantEntries || [], null, 4)};`;
+        finalHtml = updatedHtml.substring(0, nonCompliantStart) + nonCompliantString + updatedHtml.substring(nonCompliantEnd);
+    } else {
+        console.error('❌ Could not find nonCompliantData array in HTML file');
+    }
+
     const { longDate } = formatDate(lastUpdated);
-    const updatedHtmlWithDate = updatedHtml
+    const updatedHtmlWithDate = finalHtml
         .replace(/Source: ESMA EMT Register, \d{1,2} \w+ \d{4}/, `Source: ESMA EMT Register, ${longDate}`)
         .replace(/Data as of [^<]+/, `Data as of ${longDate}`);
 
@@ -211,6 +333,9 @@ function updateHtmlFile(newData, lastUpdated) {
     console.log(`   USD Tokens: ${usdTokens}`);
     console.log(`   GBP Tokens: ${gbpTokens}`);
     console.log(`   CZK Tokens: ${czkTokens}`);
+    if (Array.isArray(nonCompliantEntries)) {
+        console.log(`   Non-compliant entities: ${nonCompliantEntries.length}`);
+    }
 }
 
 // Main execution
@@ -218,9 +343,14 @@ async function main() {
     console.log('🔄 Fetching data from Google Sheets...');
     console.log('🌐 Data URL:', csvUrl);
     console.log('🌐 Date URL:', dateUrl);
+    console.log('🌐 Non-compliant URL:', nonCompliantUrl);
 
     try {
-        const [data, dateCsv] = await Promise.all([fetchCsv(csvUrl), fetchCsv(dateUrl)]);
+        const [data, dateCsv, nonCompliantCsv] = await Promise.all([
+            fetchCsv(csvUrl),
+            fetchCsv(dateUrl),
+            fetchCsv(nonCompliantUrl)
+        ]);
         console.log('📋 Raw CSV length:', data.length, 'characters');
         console.log('📋 First 200 characters:', data.substring(0, 200));
 
@@ -242,10 +372,16 @@ async function main() {
             process.exit(1);
         }
 
+        const nonCompliantArray = csvToArrayGeneric(nonCompliantCsv);
+        console.log('🚨 Parsed', nonCompliantArray.length, 'non-compliant rows');
+
+        const nonCompliantEntries = convertToNonCompliantData(nonCompliantArray);
+        console.log('🚨 Converted to', nonCompliantEntries.length, 'non-compliant entities');
+
         const sheetDate = extractDateFromCsv(dateCsv);
         console.log('📅 Sheet date:', sheetDate);
 
-        updateHtmlFile(jsData, sheetDate);
+        updateHtmlFile(jsData, sheetDate, nonCompliantEntries);
     } catch (error) {
         console.error('❌ Error fetching CSV:', error);
         process.exit(1);


### PR DESCRIPTION
## Summary
- allow the Update EMT Dashboard workflow to forward sheet URLs from repository variables or secrets when running the sync script

## Testing
- ⚠️ `node update-data.js` *(fails: network access to Google Sheets is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d51f63db58832faf4bab81b2695ade