### PR TITLE
Add EMT insights heading and clarify distribution chart titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,11 @@
     </div>
 
     <div class="max-w-7xl mx-auto px-6 py-8">
+    <div class="mb-6 text-white">
+    <h2 class="text-2xl font-semibold">EMT Issuer Insights</h2>
+    <p class="text-blue-100">Key indicators and distributions for licensed Electronic Money Token issuers.</p>
+    </div>
+
     <!-- KPI Cards Container - Dynamic -->
     <div id="kpiContainer" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-6 mb-8 fade-in">
     <!-- Will be populated dynamically by JavaScript -->
@@ -206,7 +211,7 @@
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
     <div class="bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 card-hover">
     <h3 class="text-xl font-bold text-gray-800 mb-4">
-    <i class="fas fa-globe-europe text-teal-600 mr-2"></i>Geographic Distribution
+    <i class="fas fa-globe-europe text-teal-600 mr-2"></i>EMT Geographic Distribution
     </h3>
     <div class="space-y-4" id="countryChart">
     <!-- Will be populated by JavaScript -->
@@ -215,7 +220,7 @@
 
     <div class="bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 card-hover">
     <h3 class="text-xl font-bold text-gray-800 mb-4">
-    <i class="fas fa-university text-blue-600 mr-2"></i>Regulatory Authorities
+    <i class="fas fa-university text-blue-600 mr-2"></i>EMT Regulatory Authorities
     </h3>
     <div class="space-y-4" id="authorityChart">
     <!-- Will be populated by JavaScript -->


### PR DESCRIPTION
## Summary
- introduce an "EMT Issuer Insights" heading with descriptive copy above the KPI and chart area to frame the EMT statistics overview
- rename the geographic and regulatory distribution chart titles to explicitly reference EMT issuers for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d54b5f1b74832f995483cfa8a77f38