### PR TITLE
Add emoji font fallbacks for body text

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
 
     body {
-    font-family: 'Inter', sans-serif;
+    font-family: 'Inter', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji', sans-serif;
     background: linear-gradient(90deg, #58c1ba, #004aad);
     min-height: 100vh;
     }


### PR DESCRIPTION
## Summary
- expand the global body font stack to include emoji-capable fallbacks for Windows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6f5f2aae4832f876f4ffb4c952952