### PR TITLE
Refine header shrink typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
     }
 
     .header-sticky.shrink h1 {
-        font-size: 1.5rem;     /* Tailwind 'text-2xl' */
+        font-size: clamp(1.1rem, 3vw, 1.6rem);
     }
 
     .header-sticky.shrink .additional-info {
@@ -362,7 +362,7 @@
     alt="DEA Logo" id="homeLogo" class="logo-container" role="button" tabindex="0"
     aria-label="Return to the default dashboard view">
     <div>
-    <h1 class="text-[1.8rem] font-bold text-white mb-1">MiCAR EMT License Tracker</h1>
+    <h1 class="text-[1.8rem] md:text-[2.2rem] font-bold text-white mb-1">MiCAR EMT License Tracker</h1>
     <p class="text-blue-100 text-lg additional-info">Electronic Money Token Issuers Analytics</p>
     </div>
     </div>


### PR DESCRIPTION
## Summary
- restore the larger default heading size for the MiCAR EMT License Tracker title
- reduce the heading size only when the sticky header shrinks on scroll to match the DEA logo

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dc41f02f3c832f9e4bc73ec073da0c