### PR TITLE
Adjust CASPs intro spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,10 +387,10 @@
     </div>
 
     <div class="max-w-7xl mx-auto px-6 py-8">
-    <div id="sectionIntro" class="mb-6 text-white">
+    <div id="sectionIntro" class="mb-6 text-white space-y-4 md:space-y-6">
     <h2 id="sectionTitle" class="text-2xl font-semibold">EMT Issuer Insights</h2>
     <p id="sectionDescription" class="text-blue-100">Key indicators and distributions for licensed Electronic Money Token issuers.</p>
-    <div id="caspsIntroKpiContainer" class="hidden grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6 mt-6 fade-in">
+    <div id="caspsIntroKpiContainer" class="hidden grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6 fade-in">
     <!-- CASPs KPI cards duplicated for section intro -->
     </div>
     </div>


### PR DESCRIPTION
## Summary
- add responsive vertical spacing inside the section intro so the CASPs KPI cards sit below the description with consistent breathing room

## Testing
- Manually loaded the dashboard in a browser to verify the CASPs cards have the intended spacing


------
https://chatgpt.com/codex/tasks/task_b_68de4e524be8832fb0997eafac37a673