### PR TITLE
Add dashboard data validation, dynamic currency handling and UI improvements; trigger Pages build in CI

### DIFF
--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write  # Explicitly grant write permissions
+  pages: write     # Allow this workflow to request a GitHub Pages rebuild
 
 jobs:
   update-dashboard:
@@ -34,6 +35,9 @@ jobs:
       run: |
         echo "🔄 Starting dashboard update..."
         node update-data.js
+
+    - name: Validate dashboard data
+      run: npm run validate:data
 
     - name: Check for changes
       id: verify-changed-files
@@ -62,6 +66,17 @@ jobs:
           exit 1
         }
         echo "🚀 Changes pushed successfully"
+
+    - name: Trigger GitHub Pages build
+      if: steps.verify-changed-files.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        echo "🚀 Requesting GitHub Pages build..."
+        gh api \
+          --method POST \
+          "repos/${{ github.repository }}/pages/builds"
+        echo "✅ GitHub Pages build requested"
 
     - name: Summary
       run: |

--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ The script parses the CSV, converts each row into a JavaScript object and then r
 
 The script reads CSV locations from the `CSV_URL` and `DATE_URL` environment variables. If they are not set, default URLs pointing to the public Google Sheet are used.
 
+## Validation
+
+Run `npm run validate:data` after updating the generated dashboard to confirm each EMT row's total token count matches the sum of its currency columns. This catches missing currency columns before the static page is deployed.
+
 ## Google Sheets API & caching
 
 - Set `GOOGLE_API_KEY` (and optionally `GOOGLE_SHEET_ID`) to allow `update-data.js` to read the registers via the Sheets API before falling back to CSV exports. The default sheet ID already targets the shared tracker.
 - The script first queries the `snapshot!A1:B3` range (gid `353293525`). If neither the EMT nor CASPs snapshot date changed since the last run, cached JSON payloads from the `data/` directory (`emts.json`, `casps.json`, `non-compliant.json`) are reused to avoid unnecessary API calls.
-- When the snapshot date changes—or when cached data is missing—the EMT (`Jurisdiction!A1:L50`, gid `0`), CASPs (`CASPs!A1:F150`, gid `1275732000`), and non-compliant (`Non Compliant!A1:E150`, gid `409089345`) ranges are fetched, converted, written back to `index.html`, and persisted under `data/` for GitHub Actions or local debugging.
+- When the snapshot date changes—or when cached data is missing—the EMT (`Jurisdiction!A1:Z100`, gid `0`), CASPs (`CASPs!A1:F150`, gid `1275732000`), and non-compliant (`Non Compliant!A1:E150`, gid `409089345`) ranges are fetched, converted, written back to `index.html`, and persisted under `data/` for GitHub Actions or local debugging.
 - All API requests include exponential backoff and structured error logging; if the API returns an error or the key is not available, the previous CSV download logic is used as a fallback automatically.

--- a/index.html
+++ b/index.html
@@ -448,6 +448,7 @@
     <table class="w-full">
     <thead>
     <tr class="bg-gradient-to-r from-teal-50 to-blue-50">
+    <th class="text-left p-4 font-semibold text-gray-700">#</th>
     <th class="text-left p-4 font-semibold text-gray-700">CASP</th>
     <th class="text-left p-4 font-semibold text-gray-700">Country</th>
     <th class="text-left p-4 font-semibold text-gray-700">Competent Authority</th>
@@ -474,22 +475,27 @@
     <h3 class="text-xl font-bold text-gray-800 mb-4 md:mb-0">
     <i class="fas fa-exclamation-triangle text-red-600 mr-2"></i>Non-Compliant Entities
     </h3>
-    <div class="flex items-center space-x-4">
+    <div class="flex flex-col md:flex-row md:items-center gap-3">
     <div class="relative">
     <input type="text" id="nonCompliantSearchInput" placeholder="Search entities, authorities, websites..." 
     class="search-input pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-red-500 focus:border-transparent w-64">
     <i class="fas fa-search absolute left-3 top-3 text-gray-400"></i>
     </div>
+    <button id="toggleNewNonCompliant" class="px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors font-semibold" aria-pressed="false">
+    <i class="fas fa-star mr-1"></i>New only
+    </button>
     <button id="clearNonCompliantSearch" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors">
     <i class="fas fa-times mr-1"></i>Clear
     </button>
     </div>
     </div>
+    <p id="nonCompliantNewSummary" class="text-sm text-gray-600 mb-4"></p>
 
     <div class="overflow-x-auto">
     <table class="w-full">
     <thead>
     <tr class="bg-gradient-to-r from-red-50 to-orange-50">
+    <th class="text-left p-4 font-semibold text-gray-700">#</th>
     <th class="text-left p-4 font-semibold text-gray-700">Entity Name</th>
     <th class="text-left p-4 font-semibold text-gray-700">Country</th>
     <th class="text-left p-4 font-semibold text-gray-700">Regulatory Authority</th>
@@ -520,8 +526,8 @@
             Digital Euro Association (DEA) MiCAR Tracker – Overview
           </p>
           <p class="text-gray-400 text-sm mt-2" id="currentDate">
-            Source: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-300 underline hover:text-blue-200">ESMA EMT Register</a> - Data as of 4 June 2026</p>
-          <p class="text-gray-400 text-sm" id="caspsDate">Source: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-300 underline hover:text-blue-200">ESMA CASPs Register</a> - Data as of 4 June 2026</p>
+            Source: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-300 underline hover:text-blue-200">ESMA EMT Register</a> - Data as of 26 June 2026</p>
+          <p class="text-gray-400 text-sm" id="caspsDate">Source: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-300 underline hover:text-blue-200">ESMA CASPs Register</a> - Data as of 26 June 2026</p>
         </div>
 
         <!-- ── Nav links + social icons ── -->
@@ -662,6 +668,22 @@
         'RON': { symbol: '🇷🇴', name: 'Romanian Leu', color: 'yellow' }
     };
 
+    const currencyBadgeStyles = {
+        orange: 'background-color: #ffedd5; color: #c2410c;',
+        coral: 'background-color: #ffe4e6; color: #be123c;',
+        purple: 'background-color: #f3e8ff; color: #7e22ce;',
+        blue: 'background-color: #dbeafe; color: #1d4ed8;',
+        green: 'background-color: #dcfce7; color: #15803d;',
+        red: 'background-color: #fee2e2; color: #b91c1c;',
+        yellow: 'background-color: #fef9c3; color: #a16207;',
+        teal: 'background-color: #ccfbf1; color: #0f766e;'
+    };
+
+    function getCurrencyBadgeStyle(currencyCode) {
+        const color = currencyInfo[currencyCode]?.color || 'green';
+        return currencyBadgeStyles[color] || currencyBadgeStyles.green;
+    }
+
     // KPI card color classes
     const kpiColors = ['kpi-teal', 'kpi-blue', 'kpi-orange', 'kpi-coral', 'kpi-purple', 'kpi-red', 'kpi-green', 'kpi-yellow'];
 
@@ -674,12 +696,14 @@
         "authority": "ACPR",
         "tokens": "EURC, USDC",
         "count": 2,
-        "euro": 1,
+        "eur": 1,
         "usd": 1,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 2,
@@ -688,12 +712,14 @@
         "authority": "ACPR",
         "tokens": "EURCV, USDCV",
         "count": 2,
-        "euro": 1,
+        "eur": 1,
         "usd": 1,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 3,
@@ -702,12 +728,14 @@
         "authority": "ACPR",
         "tokens": "EURØP",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 4,
@@ -716,12 +744,14 @@
         "authority": "ACPR",
         "tokens": "EUROD",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 5,
@@ -730,12 +760,14 @@
         "authority": "ACPR",
         "tokens": "HEURO",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 6,
@@ -744,12 +776,14 @@
         "authority": "FIN-FSA",
         "tokens": "EUROe, eUSD, USDG",
         "count": 3,
-        "euro": 1,
+        "eur": 1,
         "usd": 2,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 7,
@@ -758,12 +792,14 @@
         "authority": "Finanstilsynet",
         "tokens": "",
         "count": 0,
-        "euro": 0,
+        "eur": 0,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 8,
@@ -772,12 +808,14 @@
         "authority": "Latvijas Banka",
         "tokens": "EURpa, USDpa",
         "count": 2,
-        "euro": 1,
+        "eur": 1,
         "usd": 1,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 9,
@@ -786,12 +824,14 @@
         "authority": "CSSF",
         "tokens": "EURI",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 10,
@@ -800,12 +840,14 @@
         "authority": "CSSF",
         "tokens": "BREUR",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 11,
@@ -814,12 +856,14 @@
         "authority": "Dutch National Bank",
         "tokens": "EURQ, USDQ, EURD, PLNQ, GBPQ, RONQ",
         "count": 6,
-        "euro": 2,
+        "eur": 2,
         "usd": 1,
         "czk": 0,
         "gbp": 1,
         "chf": 0,
-        "pln": 1
+        "pln": 1,
+        "sek": 0,
+        "ron": 1
     },
     {
         "id": 12,
@@ -828,12 +872,14 @@
         "authority": "MFSA",
         "tokens": "USDR, EURR",
         "count": 2,
-        "euro": 1,
+        "eur": 1,
         "usd": 1,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 13,
@@ -842,12 +888,14 @@
         "authority": "MFSA",
         "tokens": "EURsm, USDsm",
         "count": 2,
-        "euro": 1,
+        "eur": 1,
         "usd": 1,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 14,
@@ -856,12 +904,14 @@
         "authority": "Bank of Lithuania",
         "tokens": "EURW",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 15,
@@ -870,12 +920,14 @@
         "authority": "Bank of Lithuania",
         "tokens": "BLUEUR",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 16,
@@ -884,12 +936,14 @@
         "authority": "Czech National Bank",
         "tokens": "CZKI",
         "count": 1,
-        "euro": 0,
+        "eur": 0,
         "usd": 0,
         "czk": 1,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 17,
@@ -898,12 +952,14 @@
         "authority": "Dutch National Bank",
         "tokens": "ENEUR, ENGBP, ENUSD",
         "count": 3,
-        "euro": 1,
+        "eur": 1,
         "usd": 1,
         "czk": 0,
         "gbp": 1,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 18,
@@ -912,12 +968,14 @@
         "authority": "BaFin",
         "tokens": "EURAU, CHFAU, SEKAU",
         "count": 3,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 1,
-        "pln": 0
+        "pln": 0,
+        "sek": 1,
+        "ron": 0
     },
     {
         "id": 19,
@@ -926,12 +984,14 @@
         "authority": "KNF",
         "tokens": "",
         "count": 0,
-        "euro": 0,
+        "eur": 0,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     },
     {
         "id": 20,
@@ -940,34 +1000,20 @@
         "authority": "Central Bank of Iceland",
         "tokens": "EURe",
         "count": 1,
-        "euro": 1,
+        "eur": 1,
         "usd": 0,
         "czk": 0,
         "gbp": 0,
         "chf": 0,
-        "pln": 0
+        "pln": 0,
+        "sek": 0,
+        "ron": 0
     }
 ];
 
     const caspsData = [
     {
         "id": 1,
-        "name": "Bybit EU GmbH",
-        "authority": "FMA",
-        "memberState": "Austria",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "placing",
-            "transfer"
-        ],
-        "websites": [
-            "https://www.bybit.eu"
-        ]
-    },
-    {
-        "id": 2,
         "name": "Bitpanda GmbH",
         "authority": "FMA",
         "memberState": "Austria",
@@ -982,6 +1028,22 @@
         ],
         "websites": [
             "https://www.bitpanda.com"
+        ]
+    },
+    {
+        "id": 2,
+        "name": "Bybit EU GmbH",
+        "authority": "FMA",
+        "memberState": "Austria",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "placing",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.bybit.eu"
         ]
     },
     {
@@ -1054,7 +1116,7 @@
             "execution"
         ],
         "websites": [
-            "https://www.dad.at/"
+            "https://www.dad.at"
         ]
     },
     {
@@ -1070,7 +1132,7 @@
             "transfer"
         ],
         "websites": [
-            "https://coinfinity.co/"
+            "https://coinfinity.co"
         ]
     },
     {
@@ -1087,6 +1149,22 @@
     },
     {
         "id": 10,
+        "name": "WB-Shields Innovations GmbH",
+        "authority": "FMA",
+        "memberState": "Austria",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "placing",
+            "transfer"
+        ],
+        "websites": [
+            "https://whitebit.eu"
+        ]
+    },
+    {
+        "id": 11,
         "name": "KBC Bank NV",
         "authority": "NBB",
         "memberState": "Belgium",
@@ -1100,7 +1178,7 @@
         ]
     },
     {
-        "id": 11,
+        "id": 12,
         "name": "Alaric Securities OOD",
         "authority": "FSC",
         "memberState": "Bulgaria",
@@ -1120,7 +1198,7 @@
         ]
     },
     {
-        "id": 12,
+        "id": 13,
         "name": "Belayer ООD",
         "authority": "FSC",
         "memberState": "Bulgaria",
@@ -1134,248 +1212,137 @@
         ]
     },
     {
-        "id": 13,
-        "name": "ELECTROCOIN Ltd for services",
-        "authority": "HANFA",
-        "memberState": "Croatia",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto"
-        ],
-        "websites": [
-            "https://electrocoin.eu/hr"
-        ]
-    },
-    {
         "id": 14,
-        "name": "WHITE TECH Limited liability company for services",
-        "authority": "HANFA",
-        "memberState": "Croatia",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "transfer"
-        ],
-        "websites": [
-            "https://whitely.hr/hr"
-        ]
-    },
-    {
-        "id": 15,
-        "name": "DIGITAL ASSETS Limited liability company for intermediation and services",
-        "authority": "HANFA",
-        "memberState": "Croatia",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "placing",
-            "RTO",
-            "transfer"
-        ],
-        "websites": [
-            "https://www.bitstore.net/"
-        ]
-    },
-    {
-        "id": 16,
         "name": "eToro (Europe) Ltd",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "execution",
-            "RTO",
-            "advice",
-            "portfolio mgmt",
-            "transfer"
-        ],
+        "services": [],
         "websites": [
             "https://www.etoro.com"
         ]
     },
     {
-        "id": 17,
+        "id": 15,
         "name": "COLLECT & EXCHANGE CY LTD",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "transfer"
-        ],
+        "services": [],
         "websites": [
             "https://collectnexchange.cy/"
         ]
     },
     {
-        "id": 18,
+        "id": 16,
         "name": "Trading 212 Markets Ltd",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "execution",
-            "RTO"
-        ],
+        "services": [],
         "websites": [
             "https://www.trading212.com"
         ]
     },
     {
-        "id": 19,
+        "id": 17,
         "name": "Stratos Europe Ltd",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto"
-        ],
+        "services": [],
         "websites": [
             "https://www.tradu.com/eu/"
         ]
     },
     {
-        "id": 20,
+        "id": 18,
         "name": "Revolut Digital Assets (Europe) Ltd",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "trading platform",
-            "exchange funds",
-            "exchange crypto",
-            "placing",
-            "transfer"
-        ],
+        "services": [],
         "websites": [
-            "https://www.revolut.com/"
+            "https://www.revolut.com/en-CY/crypto/"
         ]
     },
     {
-        "id": 21,
+        "id": 19,
         "name": "TEROXX DIGITAL ASSET LTD",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "placing",
-            "advice",
-            "portfolio mgmt",
-            "transfer"
-        ],
+        "services": [],
         "websites": [
             "https://www.teroxx.com"
         ]
     },
     {
-        "id": 22,
+        "id": 20,
         "name": "CAPITAL VAULT LTD",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "execution"
-        ],
+        "services": [],
         "websites": [
             "https://www.capital.com"
         ]
     },
     {
-        "id": 23,
+        "id": 21,
         "name": "PELICAN EXCHANGE EUROPE (CY) LTD",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "execution",
-            "RTO",
-            "advice",
-            "portfolio mgmt"
-        ],
+        "services": [],
         "websites": [
             "https://www.pelicaneu.com"
         ]
     },
     {
-        "id": 24,
+        "id": 22,
         "name": "XTB Limited",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "execution",
-            "RTO"
-        ],
+        "services": [],
         "websites": [
             "https://www.xtb.com/cy"
         ]
     },
     {
-        "id": 25,
+        "id": 23,
         "name": "Noemon Finance Ltd",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "execution",
-            "RTO",
-            "advice",
-            "portfolio mgmt"
-        ],
+        "services": [],
         "websites": [
             "https://www.noemon.finance"
         ]
     },
     {
-        "id": 26,
+        "id": 24,
         "name": "Trading.com Markets EU Ltd",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "execution",
-            "RTO",
-            "portfolio mgmt"
-        ],
+        "services": [],
         "websites": [
             "https://www.trading.com/eu"
         ]
     },
     {
-        "id": 27,
+        "id": 25,
         "name": "J2TX Ltd",
         "authority": "CySEC",
         "memberState": "Cyprus",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "execution",
-            "RTO",
-            "advice",
-            "portfolio mgmt",
-            "transfer"
-        ],
+        "services": [],
         "websites": [
             "https://www.j2tx.com"
         ]
     },
     {
-        "id": 28,
+        "id": 26,
+        "name": "S.K. DASK KRYPTO LTD",
+        "authority": "CySEC",
+        "memberState": "Cyprus",
+        "services": [],
+        "websites": [
+            "https://www.daskcapital.io"
+        ]
+    },
+    {
+        "id": 27,
         "name": "Invity Finance s.r.o.",
         "authority": "CNB",
         "memberState": "Czechia",
@@ -1389,6 +1356,16 @@
         ],
         "websites": [
             "https://www.invity.io"
+        ]
+    },
+    {
+        "id": 28,
+        "name": "NAGA X",
+        "authority": "CySEC",
+        "memberState": "Cyprus",
+        "services": [],
+        "websites": [
+            "https://www.nagax.com/eu/"
         ]
     },
     {
@@ -1487,93 +1464,6 @@
     },
     {
         "id": 35,
-        "name": "Penning Financial Services ApS",
-        "authority": "DFSA",
-        "memberState": "Denmark",
-        "services": [
-            "custody",
-            "exchange funds",
-            "exchange crypto",
-            "execution",
-            "RTO",
-            "portfolio mgmt",
-            "transfer"
-        ],
-        "websites": [
-            "https://www.penning.io"
-        ]
-    },
-    {
-        "id": 36,
-        "name": "Lunar Block A/S",
-        "authority": "DFSA",
-        "memberState": "Denmark",
-        "services": [
-            "custody",
-            "execution"
-        ],
-        "websites": [
-            "https://www.lunar.app/dk/privat/krypto"
-        ]
-    },
-    {
-        "id": 37,
-        "name": "GC Exchange A/S",
-        "authority": "DFSA",
-        "memberState": "Denmark",
-        "services": [
-            "exchange funds",
-            "exchange crypto",
-            "execution",
-            "transfer"
-        ],
-        "websites": [
-            "https://gc.exchange/"
-        ]
-    },
-    {
-        "id": 38,
-        "name": "Northstake ApS",
-        "authority": "DFSA",
-        "memberState": "Denmark",
-        "services": [
-            "custody",
-            "execution",
-            "transfer"
-        ],
-        "websites": [
-            "https://www.northstake.dk"
-        ]
-    },
-    {
-        "id": 39,
-        "name": "Lightyear Europe AS",
-        "authority": "EFSA",
-        "memberState": "Estonia",
-        "services": [
-            "custody",
-            "execution",
-            "RTO"
-        ],
-        "websites": [
-            "https://lightyear.com/"
-        ]
-    },
-    {
-        "id": 40,
-        "name": "AS LHV Pank",
-        "authority": "EFSA",
-        "memberState": "Estonia",
-        "services": [
-            "custody",
-            "RTO"
-        ],
-        "websites": [
-            "https://www.lhv.ee"
-        ]
-    },
-    {
-        "id": 41,
         "name": "Boerse Stuttgart Digital Custody GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1586,7 +1476,7 @@
         ]
     },
     {
-        "id": 42,
+        "id": 36,
         "name": "Bitpanda Asset Management GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1601,7 +1491,7 @@
         ]
     },
     {
-        "id": 43,
+        "id": 37,
         "name": "Tradias GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1617,19 +1507,20 @@
         ]
     },
     {
-        "id": 44,
+        "id": 38,
         "name": "EUWAX AG",
         "authority": "BaFin",
         "memberState": "Germany",
         "services": [
-            "execution"
+            "exchange funds",
+            "exchange crypto"
         ],
         "websites": [
             "https://www.euwax-ag.de"
         ]
     },
     {
-        "id": 45,
+        "id": 39,
         "name": "flatexDEGIRO Bank AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1637,11 +1528,11 @@
             "execution"
         ],
         "websites": [
-            "https://www.flatexdegiro.com/"
+            "https://www.flatexdegiro.com/de/flatexdegiro-bank/login"
         ]
     },
     {
-        "id": 46,
+        "id": 40,
         "name": "360 Treasury Systems AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1653,7 +1544,7 @@
         ]
     },
     {
-        "id": 47,
+        "id": 41,
         "name": "Trade Republic Bank GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1668,7 +1559,7 @@
         ]
     },
     {
-        "id": 48,
+        "id": 42,
         "name": "BitGo Europe GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1681,11 +1572,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.bitgo.de/entities/"
+            "https://www.bitgo.de/entities/bitgoeuropegmbh/"
         ]
     },
     {
-        "id": 49,
+        "id": 43,
         "name": "N26 Bank SE",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1693,11 +1584,12 @@
             "RTO"
         ],
         "websites": [
-            "https://n26.com"
+            "N26 – Die erste Onlinebank",
+            "die du lieben wirst"
         ]
     },
     {
-        "id": 50,
+        "id": 44,
         "name": "Baader Bank Aktiengesellschaft",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1709,7 +1601,7 @@
         ]
     },
     {
-        "id": 51,
+        "id": 45,
         "name": "Commerzbank Aktiengesellschaft",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1718,11 +1610,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.commerzbank.de"
+            "Commerzbank AG – Investor Relations"
         ]
     },
     {
-        "id": 52,
+        "id": 46,
         "name": "Baden-Württembergische Wertpapierbörse GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1734,7 +1626,7 @@
         ]
     },
     {
-        "id": 53,
+        "id": 47,
         "name": "Crypto Finance (Deutschland) GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1746,11 +1638,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.crypto-finance.com/"
+            "https://www.crypto-finance.com/germany/de/"
         ]
     },
     {
-        "id": 54,
+        "id": 48,
         "name": "Traders Place GmbH & Co. KGaA",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1758,11 +1650,11 @@
             "RTO"
         ],
         "websites": [
-            "https://tradersplace.de/"
+            "https://tradersplace.de/angebot/uebersicht/kryptowaehrungen"
         ]
     },
     {
-        "id": 55,
+        "id": 49,
         "name": "Tangany GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1775,7 +1667,7 @@
         ]
     },
     {
-        "id": 56,
+        "id": 50,
         "name": "Smartbroker AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1783,11 +1675,11 @@
             "RTO"
         ],
         "websites": [
-            "https://www.smartbrokerplus.de/"
+            "https://www.smartbrokerplus.de/de-de/"
         ]
     },
     {
-        "id": 57,
+        "id": 51,
         "name": "Dietrich & Richter Private Asset Management AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1800,7 +1692,7 @@
         ]
     },
     {
-        "id": 58,
+        "id": 52,
         "name": "Bullish Europe GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1816,7 +1708,7 @@
         ]
     },
     {
-        "id": 59,
+        "id": 53,
         "name": "V-Bank AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1830,25 +1722,23 @@
         ]
     },
     {
-        "id": 60,
+        "id": 54,
         "name": "Bankhaus Scheich Wertpapierspezialist AG",
         "authority": "BaFin",
         "memberState": "Germany",
         "services": [
             "exchange funds",
-            "exchange crypto",
             "execution",
             "placing",
             "RTO",
-            "advice",
-            "portfolio mgmt"
+            "advice"
         ],
         "websites": [
             "https://www.bankhaus-scheich.de"
         ]
     },
     {
-        "id": 61,
+        "id": 55,
         "name": "Lang & Schwarz TradeCenter AG & Co. KG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1861,7 +1751,7 @@
         ]
     },
     {
-        "id": 62,
+        "id": 56,
         "name": "DonauCapital Wertpapier GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1873,7 +1763,7 @@
         ]
     },
     {
-        "id": 63,
+        "id": 57,
         "name": "Volksbank Raiffeisenbank Bayern Mitte eG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1886,7 +1776,7 @@
         ]
     },
     {
-        "id": 64,
+        "id": 58,
         "name": "Huddlestock GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1898,7 +1788,7 @@
         ]
     },
     {
-        "id": 65,
+        "id": 59,
         "name": "sino Aktiengesellschaft",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1910,7 +1800,7 @@
         ]
     },
     {
-        "id": 66,
+        "id": 60,
         "name": "Hyphe Markets GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1922,7 +1812,7 @@
         ]
     },
     {
-        "id": 67,
+        "id": 61,
         "name": "Deutsche WertpapierService Bank AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1934,7 +1824,7 @@
         ]
     },
     {
-        "id": 68,
+        "id": 62,
         "name": "DekaBank Deutsche Girozentrale",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1948,7 +1838,19 @@
         ]
     },
     {
-        "id": 69,
+        "id": 63,
+        "name": "EUWAX AG",
+        "authority": "BaFin",
+        "memberState": "Germany",
+        "services": [
+            "execution"
+        ],
+        "websites": [
+            "https://www.euwax-ag.de"
+        ]
+    },
+    {
+        "id": 64,
         "name": "Hauck Aufhäuser Digital Custody GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1957,11 +1859,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.hal-privatbank.com/"
+            "https://www.hal-privatbank.com/asset-servicing/digitale-assets/regulierte-kryptoverwahrung"
         ]
     },
     {
-        "id": 70,
+        "id": 65,
         "name": "Fels wealth GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1976,7 +1878,7 @@
         ]
     },
     {
-        "id": 71,
+        "id": 66,
         "name": "Westerwald Bank eG Volks- und Raiffeisenbank",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -1988,7 +1890,7 @@
         ]
     },
     {
-        "id": 72,
+        "id": 67,
         "name": "Hannoversche Volksbank eG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2000,7 +1902,7 @@
         ]
     },
     {
-        "id": 73,
+        "id": 68,
         "name": "VR TeilhaberBank Metropolregion Nürnberg eG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2012,7 +1914,7 @@
         ]
     },
     {
-        "id": 74,
+        "id": 69,
         "name": "Volksbank Mittlerer Schwarzwald eG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2024,7 +1926,7 @@
         ]
     },
     {
-        "id": 75,
+        "id": 70,
         "name": "IG Europe GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2039,7 +1941,7 @@
         ]
     },
     {
-        "id": 76,
+        "id": 71,
         "name": "Volksbank Raiffeisenbank Würzburg eG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2051,7 +1953,7 @@
         ]
     },
     {
-        "id": 77,
+        "id": 72,
         "name": "VR-Bank Rottal-Inn eG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2063,7 +1965,7 @@
         ]
     },
     {
-        "id": 78,
+        "id": 73,
         "name": "VR Bank Südpfalz eG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2075,7 +1977,7 @@
         ]
     },
     {
-        "id": 79,
+        "id": 74,
         "name": "Sutor Bank GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2087,7 +1989,7 @@
         ]
     },
     {
-        "id": 80,
+        "id": 75,
         "name": "wSw PortfolioManagement AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2099,7 +2001,7 @@
         ]
     },
     {
-        "id": 81,
+        "id": 76,
         "name": "FIDUS Finanz AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2114,7 +2016,7 @@
         ]
     },
     {
-        "id": 82,
+        "id": 77,
         "name": "DZ BANK AG Deutsche Zentral-Genossenschaftsbank",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2128,7 +2030,7 @@
         ]
     },
     {
-        "id": 83,
+        "id": 78,
         "name": "Tradevest Digital Assets GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2141,7 +2043,7 @@
         ]
     },
     {
-        "id": 84,
+        "id": 79,
         "name": "ISF Institut Deutsch-Schweizer Finanzdienstleistungen GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2153,7 +2055,7 @@
         ]
     },
     {
-        "id": 85,
+        "id": 80,
         "name": "Plutos Vermögensverwaltung AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2165,7 +2067,7 @@
         ]
     },
     {
-        "id": 86,
+        "id": 81,
         "name": "Scalable Capital Bank GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2177,7 +2079,7 @@
         ]
     },
     {
-        "id": 87,
+        "id": 82,
         "name": "AnCeKa Vermögensbetreuungs Aktiengesellschaft",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2191,7 +2093,7 @@
         ]
     },
     {
-        "id": 88,
+        "id": 83,
         "name": "Joh. Berenberg, Gossler & Co. KG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2208,7 +2110,7 @@
         ]
     },
     {
-        "id": 89,
+        "id": 84,
         "name": "MLP Banking AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2220,7 +2122,7 @@
         ]
     },
     {
-        "id": 90,
+        "id": 85,
         "name": "BV & P Vermögen AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2233,7 +2135,7 @@
         ]
     },
     {
-        "id": 91,
+        "id": 86,
         "name": "CONCEDUS GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2246,7 +2148,7 @@
         ]
     },
     {
-        "id": 92,
+        "id": 87,
         "name": "DLT Securities GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2264,7 +2166,7 @@
         ]
     },
     {
-        "id": 93,
+        "id": 88,
         "name": "Tradevest Markets AG",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2281,7 +2183,7 @@
         ]
     },
     {
-        "id": 94,
+        "id": 89,
         "name": "Vermögensbutler GmbH",
         "authority": "BaFin",
         "memberState": "Germany",
@@ -2294,23 +2196,121 @@
         ]
     },
     {
-        "id": 95,
-        "name": "CHECKSIG S.R.L. SOCIETÀ BENEFIT",
-        "authority": "CONSOB",
-        "memberState": "Italy",
+        "id": 90,
+        "name": "Volksbank Heiden eG",
+        "authority": "BaFin",
+        "memberState": "Germany",
+        "services": [
+            "execution"
+        ],
+        "websites": [
+            "https://www.vbheiden.de"
+        ]
+    },
+    {
+        "id": 91,
+        "name": "Raiffeisenbank Kreis Kelheim eG",
+        "authority": "BaFin",
+        "memberState": "Germany",
+        "services": [
+            "execution"
+        ],
+        "websites": [
+            "https://www.rbkk.de"
+        ]
+    },
+    {
+        "id": 92,
+        "name": "Penning Financial Services ApS",
+        "authority": "DFSA",
+        "memberState": "Denmark",
         "services": [
             "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "RTO",
+            "portfolio mgmt",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.penning.io"
+        ]
+    },
+    {
+        "id": 93,
+        "name": "Lunar Block A/S",
+        "authority": "DFSA",
+        "memberState": "Denmark",
+        "services": [
+            "custody",
+            "execution"
+        ],
+        "websites": [
+            "https://www.lunar.app/dk/privat/krypto"
+        ]
+    },
+    {
+        "id": 94,
+        "name": "GC Exchange A/S",
+        "authority": "DFSA",
+        "memberState": "Denmark",
+        "services": [
             "exchange funds",
             "exchange crypto",
             "execution",
             "transfer"
         ],
         "websites": [
-            "https://WWW.CHECKSIG.COM"
+            "https://gc.exchange/"
+        ]
+    },
+    {
+        "id": 95,
+        "name": "Northstake ApS",
+        "authority": "DFSA",
+        "memberState": "Denmark",
+        "services": [
+            "custody",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.northstake.dk"
         ]
     },
     {
         "id": 96,
+        "name": "Lightyear Europe AS",
+        "authority": "EFSA",
+        "memberState": "Estonia",
+        "services": [],
+        "websites": [
+            "https://lightyear.com/"
+        ]
+    },
+    {
+        "id": 97,
+        "name": "AS LHV Pank",
+        "authority": "EFSA",
+        "memberState": "Estonia",
+        "services": [],
+        "websites": [
+            "https://www.lhv.ee"
+        ]
+    },
+    {
+        "id": 98,
+        "name": "Lightspark Payments Europe AS",
+        "authority": "EFSA",
+        "memberState": "Estonia",
+        "services": [],
+        "websites": [
+            "https://eu.lightspark.com/"
+        ]
+    },
+    {
+        "id": 99,
         "name": "Banco Bilbao Vizcaya Argentaria S.A.",
         "authority": "CNMV",
         "memberState": "Spain",
@@ -2324,7 +2324,20 @@
         ]
     },
     {
-        "id": 97,
+        "id": 100,
+        "name": "OPEN BANK S.A.",
+        "authority": "CNMV",
+        "memberState": "Spain",
+        "services": [
+            "custody",
+            "execution"
+        ],
+        "websites": [
+            "https://www.openbank.es"
+        ]
+    },
+    {
+        "id": 101,
         "name": "CECABANK S.A.",
         "authority": "CNMV",
         "memberState": "Spain",
@@ -2338,7 +2351,7 @@
         ]
     },
     {
-        "id": 98,
+        "id": 102,
         "name": "Bitcoinforme S.L.",
         "authority": "CNMV",
         "memberState": "Spain",
@@ -2356,7 +2369,7 @@
         ]
     },
     {
-        "id": 99,
+        "id": 103,
         "name": "RENTA 4 BANCO S.A.",
         "authority": "CNMV",
         "memberState": "Spain",
@@ -2370,7 +2383,21 @@
         ]
     },
     {
-        "id": 100,
+        "id": 104,
+        "name": "KUTXABANK S.A.",
+        "authority": "CNMV",
+        "memberState": "Spain",
+        "services": [
+            "custody",
+            "RTO",
+            "transfer"
+        ],
+        "websites": [
+            "https://portal.kutxabank.es/cs/ Satellite/kb/es/particulares"
+        ]
+    },
+    {
+        "id": 105,
         "name": "CAIXABANK S.A.",
         "authority": "CNMV",
         "memberState": "Spain",
@@ -2385,34 +2412,20 @@
         ]
     },
     {
-        "id": 101,
-        "name": "KUTXABANK S.A.",
+        "id": 106,
+        "name": "DUE NETWORK S.L.",
         "authority": "CNMV",
         "memberState": "Spain",
         "services": [
-            "custody",
-            "RTO",
-            "transfer"
+            "exchange funds",
+            "exchange crypto"
         ],
         "websites": [
-            "https://portal.kutxabank.es"
+            "http://www.opendue.com/"
         ]
     },
     {
-        "id": 102,
-        "name": "OPEN BANK S.A.",
-        "authority": "CNMV",
-        "memberState": "Spain",
-        "services": [
-            "custody",
-            "execution"
-        ],
-        "websites": [
-            "https://www.openbank.es"
-        ]
-    },
-    {
-        "id": 103,
+        "id": 107,
         "name": "Coinmotion Oy",
         "authority": "FIN-FSA",
         "memberState": "Finland",
@@ -2427,7 +2440,7 @@
         ]
     },
     {
-        "id": 104,
+        "id": 108,
         "name": "Tesseract Investment Oy",
         "authority": "FIN-FSA",
         "memberState": "Finland",
@@ -2443,7 +2456,7 @@
         ]
     },
     {
-        "id": 105,
+        "id": 109,
         "name": "Bittimaatti Oy",
         "authority": "FIN-FSA",
         "memberState": "Finland",
@@ -2455,7 +2468,7 @@
         ]
     },
     {
-        "id": 106,
+        "id": 110,
         "name": "NorthCrypto Oy",
         "authority": "FIN-FSA",
         "memberState": "Finland",
@@ -2470,7 +2483,7 @@
         ]
     },
     {
-        "id": 107,
+        "id": 111,
         "name": "Kvarn Capital Oy",
         "authority": "FIN-FSA",
         "memberState": "Finland",
@@ -2485,7 +2498,7 @@
         ]
     },
     {
-        "id": 108,
+        "id": 112,
         "name": "CACEIS BANK",
         "authority": "AMF",
         "memberState": "France",
@@ -2499,7 +2512,7 @@
         ]
     },
     {
-        "id": 109,
+        "id": 113,
         "name": "COINSHARES ASSET MANAGEMENT",
         "authority": "AMF",
         "memberState": "France",
@@ -2512,7 +2525,7 @@
         ]
     },
     {
-        "id": 110,
+        "id": 114,
         "name": "BITSTACK DIGITAL ASSETS SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2528,7 +2541,7 @@
         ]
     },
     {
-        "id": 111,
+        "id": 115,
         "name": "METAL GEAR SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2543,7 +2556,7 @@
         ]
     },
     {
-        "id": 112,
+        "id": 116,
         "name": "DEBLOCK SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2557,7 +2570,7 @@
         ]
     },
     {
-        "id": 113,
+        "id": 117,
         "name": "GOin SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2575,7 +2588,7 @@
         ]
     },
     {
-        "id": 114,
+        "id": 118,
         "name": "FINCTEK UE SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2592,7 +2605,7 @@
         ]
     },
     {
-        "id": 115,
+        "id": 119,
         "name": "RELAI EU SASU",
         "authority": "AMF",
         "memberState": "France",
@@ -2600,11 +2613,11 @@
             "exchange funds"
         ],
         "websites": [
-            "https://relai.app/"
+            "75012 Paris"
         ]
     },
     {
-        "id": 116,
+        "id": 120,
         "name": "SOCIETE GENERALE - FORGE",
         "authority": "AMF",
         "memberState": "France",
@@ -2613,11 +2626,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.sgforge.com/"
+            "92800 PUTEAUX"
         ]
     },
     {
-        "id": 117,
+        "id": 121,
         "name": "BANQUE DELUBAC ET CIE",
         "authority": "AMF",
         "memberState": "France",
@@ -2631,11 +2644,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.delubac.com/"
+            "07160 LE CHEYLARD"
         ]
     },
     {
-        "id": 118,
+        "id": 122,
         "name": "COMETH SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2649,7 +2662,7 @@
         ]
     },
     {
-        "id": 119,
+        "id": 123,
         "name": "FIPTO PI SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2665,7 +2678,7 @@
         ]
     },
     {
-        "id": 120,
+        "id": 124,
         "name": "HEXARQ SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2681,7 +2694,7 @@
         ]
     },
     {
-        "id": 121,
+        "id": 125,
         "name": "BLOCKNODES SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2698,7 +2711,7 @@
         ]
     },
     {
-        "id": 122,
+        "id": 126,
         "name": "CIRCLE INTERNET FINANCIAL EUROPE SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2711,7 +2724,7 @@
         ]
     },
     {
-        "id": 123,
+        "id": 127,
         "name": "DESKOIN SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2728,7 +2741,7 @@
         ]
     },
     {
-        "id": 124,
+        "id": 128,
         "name": "COINHOUSE SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2746,7 +2759,7 @@
         ]
     },
     {
-        "id": 125,
+        "id": 129,
         "name": "QWARKS SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2763,7 +2776,7 @@
         ]
     },
     {
-        "id": 126,
+        "id": 130,
         "name": "PAYTOP SAS",
         "authority": "AMF",
         "memberState": "France",
@@ -2777,7 +2790,180 @@
         ]
     },
     {
-        "id": 127,
+        "id": 131,
+        "name": "RUFIJI CAPITAL SAS",
+        "authority": "AMF",
+        "memberState": "France",
+        "services": [
+            "custody",
+            "execution",
+            "advice",
+            "portfolio mgmt",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.rufiji.capital/"
+        ]
+    },
+    {
+        "id": 132,
+        "name": "KEYROCK FR SAS",
+        "authority": "AMF",
+        "memberState": "France",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://keyrock.com/"
+        ]
+    },
+    {
+        "id": 133,
+        "name": "Bpifrance Investissement",
+        "authority": "AMF",
+        "memberState": "France",
+        "services": [
+            "advice"
+        ],
+        "websites": [
+            "https://www.bpifrance.fr/"
+        ]
+    },
+    {
+        "id": 134,
+        "name": "RCUBE ASSET MANAGEMENT",
+        "authority": "AMF",
+        "memberState": "France",
+        "services": [
+            "advice",
+            "portfolio mgmt"
+        ],
+        "websites": [
+            "https://rcube.com/"
+        ]
+    },
+    {
+        "id": 135,
+        "name": "PAYMIUM SAS",
+        "authority": "AMF",
+        "memberState": "France",
+        "services": [
+            "custody",
+            "trading platform",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.paymium.com/"
+        ]
+    },
+    {
+        "id": 136,
+        "name": "LEONOD SARL",
+        "authority": "AMF",
+        "memberState": "France",
+        "services": [
+            "exchange funds"
+        ],
+        "websites": [
+            "https://app.bullbitcoin.com/"
+        ]
+    },
+    {
+        "id": 137,
+        "name": "MERIA SAS",
+        "authority": "AMF",
+        "memberState": "France",
+        "services": [
+            "custody",
+            "exchange funds",
+            "execution",
+            "advice",
+            "portfolio mgmt",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.meria.com/"
+        ]
+    },
+    {
+        "id": 138,
+        "name": "ELECTROCOIN Ltd for services",
+        "authority": "HANFA",
+        "memberState": "Croatia",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto"
+        ],
+        "websites": [
+            "https://electrocoin.eu/hr"
+        ]
+    },
+    {
+        "id": 139,
+        "name": "WHITE TECH Limited liability company for services",
+        "authority": "HANFA",
+        "memberState": "Croatia",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "transfer"
+        ],
+        "websites": [
+            "https://whitely.hr/hr"
+        ]
+    },
+    {
+        "id": 140,
+        "name": "DIGITAL ASSETS Limited liability company for intermediation and services",
+        "authority": "HANFA",
+        "memberState": "Croatia",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "placing",
+            "RTO",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.bitstore.net/"
+        ]
+    },
+    {
+        "id": 141,
+        "name": "Bitblock Ltd. for Services",
+        "authority": "HANFA",
+        "memberState": "Croatia",
+        "services": [
+            "exchange funds"
+        ],
+        "websites": [
+            "https://kriptomat.hr/"
+        ]
+    },
+    {
+        "id": 142,
+        "name": "IN KAPITAL limited liability company for trade and services",
+        "authority": "HANFA",
+        "memberState": "Croatia",
+        "services": [
+            "exchange funds"
+        ],
+        "websites": [
+            "https://www.inkapital.hr/"
+        ]
+    },
+    {
+        "id": 143,
         "name": "Payward Global Solutions Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2789,7 +2975,7 @@
         ]
     },
     {
-        "id": 128,
+        "id": 144,
         "name": "Payward Europe Solutions Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2808,7 +2994,7 @@
         ]
     },
     {
-        "id": 129,
+        "id": 145,
         "name": "Legend Financial Ireland Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2821,7 +3007,7 @@
         ]
     },
     {
-        "id": 130,
+        "id": 146,
         "name": "Push Virtual Assets Ireland Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2834,7 +3020,7 @@
         ]
     },
     {
-        "id": 131,
+        "id": 147,
         "name": "Ramp Swaps (Ireland) Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2846,7 +3032,7 @@
         ]
     },
     {
-        "id": 132,
+        "id": 148,
         "name": "Paysafe Payment Solutions Limited.",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2857,11 +3043,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.skrill.com"
+            "www.skrill.com"
         ]
     },
     {
-        "id": 133,
+        "id": 149,
         "name": "CoinJar Europe Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2876,7 +3062,7 @@
         ]
     },
     {
-        "id": 134,
+        "id": 150,
         "name": "Confirmo Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2890,7 +3076,7 @@
         ]
     },
     {
-        "id": 135,
+        "id": 151,
         "name": "Pionew Ireland Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2905,7 +3091,7 @@
         ]
     },
     {
-        "id": 136,
+        "id": 152,
         "name": "StoneX Digital International Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2922,7 +3108,7 @@
         ]
     },
     {
-        "id": 137,
+        "id": 153,
         "name": "Interactive Brokers Ireland Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2934,7 +3120,7 @@
         ]
     },
     {
-        "id": 138,
+        "id": 154,
         "name": "Virtu Financial Ireland Limited",
         "authority": "CBI",
         "memberState": "Ireland",
@@ -2947,7 +3133,81 @@
         ]
     },
     {
-        "id": 139,
+        "id": 155,
+        "name": "Myntkaup ehf.",
+        "authority": "Central Bank of Iceland",
+        "memberState": "Iceland",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "transfer"
+        ],
+        "websites": [
+            "https://myntkaup.is/"
+        ]
+    },
+    {
+        "id": 156,
+        "name": "CHECKSIG S.R.L. SOCIETÀ BENEFIT",
+        "authority": "CONSOB",
+        "memberState": "Italy",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://WWW.CHECKSIG.COM"
+        ]
+    },
+    {
+        "id": 157,
+        "name": "OLLIV ITALIA S.R.L.",
+        "authority": "CONSOB",
+        "memberState": "Italy",
+        "services": [
+            "exchange funds"
+        ],
+        "websites": [
+            "https://coinflip.tech/it-IT"
+        ]
+    },
+    {
+        "id": 158,
+        "name": "RIV-DIGITAL S.R.L.",
+        "authority": "CONSOB",
+        "memberState": "Italy",
+        "services": [
+            "exchange funds",
+            "exchange crypto",
+            "placing"
+        ],
+        "websites": [
+            "https://riv-digital.it"
+        ]
+    },
+    {
+        "id": 159,
+        "name": "CONIO S.R.L.",
+        "authority": "CONSOB",
+        "memberState": "Italy",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "placing",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.conio.com"
+        ]
+    },
+    {
+        "id": 160,
         "name": "ZEUS Anstalt für Vermögensverwaltung",
         "authority": "FMA-LI",
         "memberState": "Liechtenstein",
@@ -2959,7 +3219,7 @@
         ]
     },
     {
-        "id": 140,
+        "id": 161,
         "name": "LGT Bank AG",
         "authority": "FMA-LI",
         "memberState": "Liechtenstein",
@@ -2974,7 +3234,7 @@
         ]
     },
     {
-        "id": 141,
+        "id": 162,
         "name": "Bank Frick AG",
         "authority": "FMA-LI",
         "memberState": "Liechtenstein",
@@ -2988,9 +3248,9 @@
         ]
     },
     {
-        "id": 142,
+        "id": 163,
         "name": "Wyden Capital AG",
-        "authority": "FMA",
+        "authority": "FMA-LI",
         "memberState": "Liechtenstein",
         "services": [
             "portfolio mgmt"
@@ -3000,9 +3260,9 @@
         ]
     },
     {
-        "id": 143,
+        "id": 164,
         "name": "Celsion Bank AG",
-        "authority": "FMA",
+        "authority": "FMA-LI",
         "memberState": "Liechtenstein",
         "services": [
             "custody",
@@ -3015,9 +3275,9 @@
         ]
     },
     {
-        "id": 144,
+        "id": 165,
         "name": "RULEMATCH Europe AG",
-        "authority": "FMA",
+        "authority": "FMA-LI",
         "memberState": "Liechtenstein",
         "services": [
             "custody",
@@ -3029,7 +3289,40 @@
         ]
     },
     {
-        "id": 145,
+        "id": 166,
+        "name": "Floin AG",
+        "authority": "FMA-LI",
+        "memberState": "Liechtenstein",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "placing",
+            "transfer"
+        ],
+        "websites": [
+            "https://floin.com/"
+        ]
+    },
+    {
+        "id": 167,
+        "name": "Bitcoin Suisse (Europe) AG",
+        "authority": "FMA-LI",
+        "memberState": "Liechtenstein",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "RTO",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.bitcoinsuisse.com"
+        ]
+    },
+    {
+        "id": 168,
         "name": "Robinhood Europe UAB",
         "authority": "LSC",
         "memberState": "Lithuania",
@@ -3044,7 +3337,7 @@
         ]
     },
     {
-        "id": 146,
+        "id": 169,
         "name": "UAB Decentralized",
         "authority": "LSC",
         "memberState": "Lithuania",
@@ -3059,7 +3352,7 @@
         ]
     },
     {
-        "id": 147,
+        "id": 170,
         "name": "Nuvei Liquidity UAB",
         "authority": "LSC",
         "memberState": "Lithuania",
@@ -3074,7 +3367,7 @@
         ]
     },
     {
-        "id": 148,
+        "id": 171,
         "name": "UAB Micar assets",
         "authority": "LSC",
         "memberState": "Lithuania",
@@ -3091,7 +3384,7 @@
         ]
     },
     {
-        "id": 149,
+        "id": 172,
         "name": "Newrails, UAB",
         "authority": "LSC",
         "memberState": "Lithuania",
@@ -3104,7 +3397,7 @@
         ]
     },
     {
-        "id": 150,
+        "id": 173,
         "name": "UAB BLUE EMI LT",
         "authority": "LSC",
         "memberState": "Lithuania",
@@ -3116,7 +3409,19 @@
         ]
     },
     {
-        "id": 151,
+        "id": 174,
+        "name": "Clearstream Banking S.A.",
+        "authority": "CSSF",
+        "memberState": "Luxembourg",
+        "services": [
+            "custody"
+        ],
+        "websites": [
+            "https://www.clearstream.com/clearstream-en/"
+        ]
+    },
+    {
+        "id": 175,
         "name": "Bitstamp Europe S.A.",
         "authority": "CSSF",
         "memberState": "Luxembourg",
@@ -3134,19 +3439,7 @@
         ]
     },
     {
-        "id": 152,
-        "name": "Clearstream Banking S.A.",
-        "authority": "CSSF",
-        "memberState": "Luxembourg",
-        "services": [
-            "custody"
-        ],
-        "websites": [
-            "https://www.clearstream.com/"
-        ]
-    },
-    {
-        "id": 153,
+        "id": 176,
         "name": "Coinbase Luxembourg S.A.",
         "authority": "CSSF",
         "memberState": "Luxembourg",
@@ -3160,11 +3453,11 @@
             "transfer"
         ],
         "websites": [
-            "https://www.coinbase.com"
+            "https://https.//coinbase.com"
         ]
     },
     {
-        "id": 154,
+        "id": 177,
         "name": "Zodia Custody (Europe) S.A.",
         "authority": "CSSF",
         "memberState": "Luxembourg",
@@ -3177,7 +3470,7 @@
         ]
     },
     {
-        "id": 155,
+        "id": 178,
         "name": "Banking Circle S.A.",
         "authority": "CSSF",
         "memberState": "Luxembourg",
@@ -3191,7 +3484,7 @@
         ]
     },
     {
-        "id": 156,
+        "id": 179,
         "name": "Swissquote Bank Europe SA",
         "authority": "CSSF",
         "memberState": "Luxembourg",
@@ -3205,7 +3498,7 @@
         ]
     },
     {
-        "id": 157,
+        "id": 180,
         "name": "B2C2 Europe Sarl",
         "authority": "CSSF",
         "memberState": "Luxembourg",
@@ -3219,7 +3512,20 @@
         ]
     },
     {
-        "id": 158,
+        "id": 181,
+        "name": "STOKR S.A.",
+        "authority": "CSSF",
+        "memberState": "Luxembourg",
+        "services": [
+            "custody",
+            "transfer"
+        ],
+        "websites": [
+            "https://stokr.io/"
+        ]
+    },
+    {
+        "id": 182,
         "name": "BlockBen SIA",
         "authority": "LB",
         "memberState": "Latvia",
@@ -3235,7 +3541,7 @@
         ]
     },
     {
-        "id": 159,
+        "id": 183,
         "name": "Nexdesk SIA",
         "authority": "LB",
         "memberState": "Latvia",
@@ -3249,7 +3555,7 @@
         ]
     },
     {
-        "id": 160,
+        "id": 184,
         "name": "SIA Paybis Europe",
         "authority": "LB",
         "memberState": "Latvia",
@@ -3266,7 +3572,7 @@
         ]
     },
     {
-        "id": 161,
+        "id": 185,
         "name": "Neverless SIA",
         "authority": "LB",
         "memberState": "Latvia",
@@ -3282,7 +3588,38 @@
         ]
     },
     {
-        "id": 162,
+        "id": 186,
+        "name": "Trek Technologies SIA",
+        "authority": "LB",
+        "memberState": "Latvia",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://eu.backpack.exchange/"
+        ]
+    },
+    {
+        "id": 187,
+        "name": "AS TWINO Investments",
+        "authority": "LB",
+        "memberState": "Latvia",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution"
+        ],
+        "websites": [
+            "https://www.twino.eu/en"
+        ]
+    },
+    {
+        "id": 188,
         "name": "OKX Europe Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3302,7 +3639,7 @@
         ]
     },
     {
-        "id": 163,
+        "id": 189,
         "name": "BP23 CA Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3319,7 +3656,7 @@
         ]
     },
     {
-        "id": 164,
+        "id": 190,
         "name": "Foris DAX MT Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3336,7 +3673,7 @@
         ]
     },
     {
-        "id": 165,
+        "id": 191,
         "name": "Zillion Bits Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3355,7 +3692,7 @@
         ]
     },
     {
-        "id": 166,
+        "id": 192,
         "name": "Altarius Asset Management Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3368,7 +3705,7 @@
         ]
     },
     {
-        "id": 167,
+        "id": 193,
         "name": "Gemini Intergalactic EU Ltd",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3386,7 +3723,7 @@
         ]
     },
     {
-        "id": 168,
+        "id": 194,
         "name": "Socios Europe Services Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3402,7 +3739,7 @@
         ]
     },
     {
-        "id": 169,
+        "id": 195,
         "name": "Gate Technology Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3419,7 +3756,7 @@
         ]
     },
     {
-        "id": 170,
+        "id": 196,
         "name": "Blue Cube (Malta) Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3435,7 +3772,7 @@
         ]
     },
     {
-        "id": 171,
+        "id": 197,
         "name": "Payhound Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3451,7 +3788,7 @@
         ]
     },
     {
-        "id": 172,
+        "id": 198,
         "name": "Damex Digital LTD",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3467,7 +3804,7 @@
         ]
     },
     {
-        "id": 173,
+        "id": 199,
         "name": "System Pay Services (Malta) Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3483,7 +3820,7 @@
         ]
     },
     {
-        "id": 174,
+        "id": 200,
         "name": "Calamatta Cuschieri Investment Services Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3496,7 +3833,7 @@
         ]
     },
     {
-        "id": 175,
+        "id": 201,
         "name": "Olmipay Limited",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3508,11 +3845,12 @@
             "transfer"
         ],
         "websites": [
-            "Olmipay.com (upcoming)"
+            "Olmipay.com",
+            "(upcoming)"
         ]
     },
     {
-        "id": 176,
+        "id": 202,
         "name": "Stable Mint Ltd.",
         "authority": "MFSA",
         "memberState": "Malta",
@@ -3525,7 +3863,38 @@
         ]
     },
     {
-        "id": 177,
+        "id": 203,
+        "name": "OP Digital Services Limited",
+        "authority": "MFSA",
+        "memberState": "Malta",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.openpayd.com/"
+        ]
+    },
+    {
+        "id": 204,
+        "name": "Zap (Strike) Europe Limited",
+        "authority": "MFSA",
+        "memberState": "Malta",
+        "services": [
+            "custody",
+            "exchange funds",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://strike.me/en-GB/"
+        ]
+    },
+    {
+        "id": 205,
         "name": "MoonPay Europe B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3539,7 +3908,7 @@
         ]
     },
     {
-        "id": 178,
+        "id": 206,
         "name": "BitStaete B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3551,7 +3920,7 @@
         ]
     },
     {
-        "id": 179,
+        "id": 207,
         "name": "Zebedee Europe B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3565,7 +3934,7 @@
         ]
     },
     {
-        "id": 180,
+        "id": 208,
         "name": "Hidden Road Partners CIV NL B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3579,7 +3948,7 @@
         ]
     },
     {
-        "id": 181,
+        "id": 209,
         "name": "AvianLabs Netherlands B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3593,7 +3962,7 @@
         ]
     },
     {
-        "id": 182,
+        "id": 210,
         "name": "Vivid Money B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3606,7 +3975,7 @@
         ]
     },
     {
-        "id": 183,
+        "id": 211,
         "name": "One Trading Exchange B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3619,7 +3988,7 @@
         ]
     },
     {
-        "id": 184,
+        "id": 212,
         "name": "Acheron Europe B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3635,7 +4004,7 @@
         ]
     },
     {
-        "id": 185,
+        "id": 213,
         "name": "BTC Direct Europe B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3649,7 +4018,7 @@
         ]
     },
     {
-        "id": 186,
+        "id": 214,
         "name": "Bitvavo B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3663,7 +4032,7 @@
         ]
     },
     {
-        "id": 187,
+        "id": 215,
         "name": "Amdax B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3678,7 +4047,7 @@
         ]
     },
     {
-        "id": 188,
+        "id": 216,
         "name": "Finst B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3693,7 +4062,7 @@
         ]
     },
     {
-        "id": 189,
+        "id": 217,
         "name": "Decubate B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3707,7 +4076,7 @@
         ]
     },
     {
-        "id": 190,
+        "id": 218,
         "name": "Fiat Republic Netherlands B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3720,7 +4089,7 @@
         ]
     },
     {
-        "id": 191,
+        "id": 219,
         "name": "BLOX B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3734,7 +4103,7 @@
         ]
     },
     {
-        "id": 192,
+        "id": 220,
         "name": "EU Internet Ventures B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3748,7 +4117,7 @@
         ]
     },
     {
-        "id": 193,
+        "id": 221,
         "name": "zerohash europe B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3760,11 +4129,11 @@
             "transfer"
         ],
         "websites": [
-            "https://zerohash.com"
+            "https://zerohash.com/eu"
         ]
     },
     {
-        "id": 194,
+        "id": 222,
         "name": "Coinmerce B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3779,7 +4148,7 @@
         ]
     },
     {
-        "id": 195,
+        "id": 223,
         "name": "Bitmymoney B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3794,7 +4163,7 @@
         ]
     },
     {
-        "id": 196,
+        "id": 224,
         "name": "Bitonic B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3809,7 +4178,7 @@
         ]
     },
     {
-        "id": 197,
+        "id": 225,
         "name": "Blockrise Capital B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3824,7 +4193,7 @@
         ]
     },
     {
-        "id": 198,
+        "id": 226,
         "name": "Monflo B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3838,7 +4207,7 @@
         ]
     },
     {
-        "id": 199,
+        "id": 227,
         "name": "WEB3 Technology B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3853,7 +4222,7 @@
         ]
     },
     {
-        "id": 200,
+        "id": 228,
         "name": "D2X Group N.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3865,7 +4234,7 @@
         ]
     },
     {
-        "id": 201,
+        "id": 229,
         "name": "ClearBank Europe N.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3879,7 +4248,7 @@
         ]
     },
     {
-        "id": 202,
+        "id": 230,
         "name": "Change Securities B.V.",
         "authority": "AFM",
         "memberState": "Netherlands",
@@ -3893,7 +4262,66 @@
         ]
     },
     {
-        "id": 203,
+        "id": 231,
+        "name": "AK JENSEN NORWAY AS",
+        "authority": "NFSA",
+        "memberState": "Norway",
+        "services": [
+            "RTO",
+            "portfolio mgmt"
+        ],
+        "websites": [
+            "https://www.akj.com/"
+        ]
+    },
+    {
+        "id": 232,
+        "name": "TÝR MARKETS AS",
+        "authority": "NFSA",
+        "memberState": "Norway",
+        "services": [
+            "custody",
+            "exchange funds",
+            "exchange crypto",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.tyrmarkets.net/no"
+        ]
+    },
+    {
+        "id": 233,
+        "name": "FIRI AS",
+        "authority": "NFSA",
+        "memberState": "Norway",
+        "services": [
+            "custody",
+            "trading platform",
+            "exchange funds",
+            "exchange crypto",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://firi.com/no"
+        ]
+    },
+    {
+        "id": 234,
+        "name": "K33 MARKETS as",
+        "authority": "NFSA",
+        "memberState": "Norway",
+        "services": [
+            "custody",
+            "execution",
+            "transfer"
+        ],
+        "websites": [
+            "https://www.k33.com"
+        ]
+    },
+    {
+        "id": 235,
         "name": "ILIRIKA borzno posredniška hiša d.d.",
         "authority": "ATVP",
         "memberState": "Slovenia",
@@ -3908,8 +4336,8 @@
         ]
     },
     {
-        "id": 204,
-        "name": "INCREMENTUM poslovne storitve d.o.o.",
+        "id": 236,
+        "name": "INCREMENTUM družba za izvajanje storitev v zvezi s kriptosredstvi d.o.o.",
         "authority": "ATVP",
         "memberState": "Slovenia",
         "services": [
@@ -3922,7 +4350,7 @@
         ]
     },
     {
-        "id": 205,
+        "id": 237,
         "name": "Orcabay finančne storitve d.o.o.",
         "authority": "ATVP",
         "memberState": "Slovenia",
@@ -3935,7 +4363,7 @@
         ]
     },
     {
-        "id": 206,
+        "id": 238,
         "name": "Safello AB",
         "authority": "FI",
         "memberState": "Sweden",
@@ -3952,7 +4380,7 @@
         ]
     },
     {
-        "id": 207,
+        "id": 239,
         "name": "Fintegence, s.r.o.",
         "authority": "NBS",
         "memberState": "Slovakia",
@@ -3966,7 +4394,7 @@
         ]
     },
     {
-        "id": 208,
+        "id": 240,
         "name": "FINTECH SK s. r. o.",
         "authority": "NBS",
         "memberState": "Slovakia",
@@ -3982,8 +4410,8 @@
         ]
     },
     {
-        "id": 209,
-        "name": "FUMBI, s. r. o.",
+        "id": 241,
+        "name": "FUMBI, s.r.o.",
         "authority": "NBS",
         "memberState": "Slovakia",
         "services": [
@@ -3999,7 +4427,7 @@
         ]
     },
     {
-        "id": 210,
+        "id": 242,
         "name": "Madison Six j. s. a.",
         "authority": "NBS",
         "memberState": "Slovakia",
@@ -4016,7 +4444,7 @@
         ]
     },
     {
-        "id": 211,
+        "id": 243,
         "name": "Firefish Europe s.r.o",
         "authority": "NBS",
         "memberState": "Slovakia",
@@ -4031,7 +4459,7 @@
         ]
     },
     {
-        "id": 212,
+        "id": 244,
         "name": "Okazio s.r.o.",
         "authority": "NBS",
         "memberState": "Slovakia",
@@ -5055,7 +5483,7 @@
         "id": 98,
         "entity": "Lucrumiagroup",
         "country": "Italy",
-        "authority": "Commissione Nazionale per le Societa e la Borsa  (CONSOB)",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
         "websites": [
             "lucrumiaofficial.co",
             "lucrumiamode.co",
@@ -5340,7 +5768,7 @@
         "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
         "websites": [
             "frame-2u-avapro.com",
-            "https:/frame-2u-avapro.org"
+            "frame-2u-avapro.org"
         ],
         "isNew": false
     },
@@ -5568,7 +5996,137 @@
     },
     {
         "id": 146,
-        "entity": "MEXC Global",
+        "entity": "RER885",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "rer885.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 147,
+        "entity": "TRUT88",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "trut88.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 148,
+        "entity": "REG775",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "reg775.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 149,
+        "entity": "SDTG99",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "sdtg99.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 150,
+        "entity": "XZD316",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "xzd316.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 151,
+        "entity": "RSD996",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "rsd996.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 152,
+        "entity": "FHF326",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "fhf326.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 153,
+        "entity": "TYT827",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "tyt827.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 154,
+        "entity": "EWTD55",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "ewtd55.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 155,
+        "entity": "DXGE85",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "dxge85.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 156,
+        "entity": "3VK1O5",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "3vk1o5.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 157,
+        "entity": "SDS323",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "sds323.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 158,
+        "entity": "KSDF12",
+        "country": "Italy",
+        "authority": "Commissione Nazionale per le Societa e la Borsa (CONSOB)",
+        "websites": [
+            "ksdf12.it"
+        ],
+        "isNew": false
+    },
+    {
+        "id": 159,
+        "entity": "MEXC",
         "country": "Netherlands",
         "authority": "Netherlands Authority for the Financial Markets (AFM)",
         "websites": [
@@ -5577,7 +6135,7 @@
         "isNew": false
     },
     {
-        "id": 147,
+        "id": 160,
         "entity": "LWEX",
         "country": "Slovakia",
         "authority": "National Bank of Slovakia (NBS)",
@@ -5591,6 +6149,7 @@
     let filteredData = [...data];
     let filteredCaspsData = [...caspsData];
     let filteredNonCompliantData = [...nonCompliantData];
+    let showNewNonCompliantOnly = false;
 
     const sectionTitleEl = document.getElementById('sectionTitle');
     const sectionDescriptionEl = document.getElementById('sectionDescription');
@@ -5990,12 +6549,7 @@
                 .filter(currency => item[currency] > 0)
                 .map(currency => {
                     const currencyCode = currency.toUpperCase();
-                    const colorClass = currencyCode === 'EUR' ? 'orange' : 
-                                     currencyCode === 'USD' ? 'pink' : 
-                                     currencyCode === 'GBP' ? 'blue' : 
-                                     currencyCode === 'CZK' ? 'purple' : 
-                                     currencyCode === 'CHF' ? 'red' : 'green';
-                    return `<span class="px-2 py-1 bg-${colorClass}-100 text-${colorClass}-700 rounded text-xs font-semibold">${currencyCode}</span>`;
+                    return `<span class="px-2 py-1 rounded text-xs font-semibold" style="${getCurrencyBadgeStyle(currencyCode)}">${currencyCode}</span>`;
                 }).join(' ');
 
             return `
@@ -6053,7 +6607,7 @@
             noResults.classList.add('hidden');
         }
 
-        tbody.innerHTML = dataToShow.map(item => {
+        tbody.innerHTML = dataToShow.map((item, index) => {
             const servicesBadges = (item.services || []).map(service => `
                 <span class="px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium">${service}</span>
             `).join(' ');
@@ -6066,6 +6620,7 @@
 
             return `
                 <tr class="border-b hover:bg-gradient-to-r hover:from-teal-50 hover:to-blue-50 transition-all duration-200">
+                    <td class="p-4 text-sm font-semibold text-gray-500">${index + 1}</td>
                     <td class="p-4">
                         <p class="text-gray-900 font-semibold">${item.name || 'N/A'}</p>
                     </td>
@@ -6086,9 +6641,31 @@
         }).join('');
     }
 
+    function updateNonCompliantNewSummary(dataToShow = filteredNonCompliantData) {
+        const summary = document.getElementById('nonCompliantNewSummary');
+        const toggle = document.getElementById('toggleNewNonCompliant');
+        const totalNew = nonCompliantData.filter(item => item.isNew).length;
+        const visibleNew = dataToShow.filter(item => item.isNew).length;
+
+        if (summary) {
+            summary.textContent = totalNew > 0
+                ? `${visibleNew} new flagged ${visibleNew === 1 ? 'entity is' : 'entities are'} visible (${totalNew} total marked new).`
+                : 'No entities are currently marked new in the latest dataset.';
+        }
+
+        if (toggle) {
+            toggle.setAttribute('aria-pressed', showNewNonCompliantOnly ? 'true' : 'false');
+            toggle.className = showNewNonCompliantOnly
+                ? 'px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold'
+                : 'px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors font-semibold';
+        }
+    }
+
     function populateNonCompliantTable(dataToShow = filteredNonCompliantData) {
         const tbody = document.getElementById('nonCompliantTable');
         const noResults = document.getElementById('noNonCompliantResults');
+
+        updateNonCompliantNewSummary(dataToShow);
 
         if (dataToShow.length === 0) {
             tbody.innerHTML = '';
@@ -6097,8 +6674,12 @@
         }
 
         noResults.classList.add('hidden');
-        tbody.innerHTML = dataToShow.map((item, index) => `
-            <tr class="border-b hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 transition-all duration-200 ${index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}">
+        tbody.innerHTML = dataToShow.map((item, index) => {
+            const rowBackground = item.isNew ? 'bg-blue-50' : (index % 2 === 0 ? 'bg-gray-50' : 'bg-white');
+
+            return `
+            <tr class="border-b hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 transition-all duration-200 ${rowBackground}">
+                <td class="p-4 text-sm font-semibold text-gray-500">${index + 1}</td>
                 <td class="p-4">
                     <div class="font-semibold text-gray-800 flex items-center">
                         <span>${item.entity}</span>
@@ -6131,7 +6712,8 @@
                     </span>
                 </td>
             </tr>
-        `).join('');
+        `;
+        }).join('');
     }
 
     // Search functionality
@@ -6171,17 +6753,18 @@
     }
 
     function filterNonCompliantData(searchTerm) {
-        if (!searchTerm.trim()) {
-            filteredNonCompliantData = [...nonCompliantData];
-        } else {
-            const term = searchTerm.toLowerCase();
-            filteredNonCompliantData = nonCompliantData.filter(item => 
+        const term = searchTerm.trim().toLowerCase();
+        filteredNonCompliantData = nonCompliantData.filter(item => {
+            const matchesSearch = !term ||
                 item.entity.toLowerCase().includes(term) ||
                 item.country.toLowerCase().includes(term) ||
                 item.authority.toLowerCase().includes(term) ||
-                item.websites.some(website => website.toLowerCase().includes(term))
-            );
-        }
+                item.websites.some(website => website.toLowerCase().includes(term));
+            const matchesNewFilter = !showNewNonCompliantOnly || item.isNew;
+
+            return matchesSearch && matchesNewFilter;
+        });
+
         populateNonCompliantTable(filteredNonCompliantData);
     }
 
@@ -6267,6 +6850,7 @@
             nonCompliantSearchInput.value = '';
         }
         filteredNonCompliantData = [...nonCompliantData];
+        showNewNonCompliantOnly = false;
         populateNonCompliantTable(filteredNonCompliantData);
     }
 
@@ -6313,8 +6897,14 @@
         filterNonCompliantData(e.target.value);
     });
 
+    document.getElementById('toggleNewNonCompliant').addEventListener('click', () => {
+        showNewNonCompliantOnly = !showNewNonCompliantOnly;
+        filterNonCompliantData(document.getElementById('nonCompliantSearchInput').value);
+    });
+
     document.getElementById('clearNonCompliantSearch').addEventListener('click', () => {
         document.getElementById('nonCompliantSearchInput').value = '';
+        showNewNonCompliantOnly = false;
         filterNonCompliantData('');
     });
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:css": "tailwindcss -i ./src/tailwind.css -o ./styles/tailwind.css"
+    "build:css": "tailwindcss -i ./src/tailwind.css -o ./styles/tailwind.css",
+    "validate:data": "node scripts/validate-dashboard-data.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/validate-dashboard-data.js
+++ b/scripts/validate-dashboard-data.js
@@ -1,0 +1,134 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..');
+const indexPath = path.join(repoRoot, 'index.html');
+const standardFields = new Set(['id', 'issuer', 'state', 'authority', 'tokens', 'count']);
+
+function fail(message, details = []) {
+  console.error(`❌ ${message}`);
+  details.forEach(detail => console.error(`   - ${detail}`));
+  process.exitCode = 1;
+}
+
+function extractDashboardData(html) {
+  const start = html.indexOf('const data = [');
+  const end = html.indexOf('const caspsData = [', start);
+
+  if (start === -1 || end === -1) {
+    throw new Error('Could not locate the EMT data block in index.html.');
+  }
+
+  const block = html.slice(start, end);
+  const match = block.match(/const data = (\[[\s\S]*?\]);\s*$/);
+
+  if (!match) {
+    throw new Error('Could not parse the EMT data array from index.html.');
+  }
+
+  return JSON.parse(match[1]);
+}
+
+function extractCurrencyInfoCodes(html) {
+  const currencyInfoMatch = html.match(/const currencyInfo = \{([\s\S]*?)\n    \};/);
+
+  if (!currencyInfoMatch) {
+    return new Set();
+  }
+
+  const codes = new Set();
+  const codePattern = /'([A-Z]{3})'\s*:/g;
+  let match;
+
+  while ((match = codePattern.exec(currencyInfoMatch[1])) !== null) {
+    codes.add(match[1]);
+  }
+
+  return codes;
+}
+
+function getCurrencyFields(items) {
+  const fields = new Set();
+
+  items.forEach(item => {
+    Object.keys(item || {}).forEach(key => {
+      if (!standardFields.has(key)) {
+        fields.add(key);
+      }
+    });
+  });
+
+  return Array.from(fields).sort();
+}
+
+function toNumber(value) {
+  const number = Number(value || 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function validateItems(items, knownCurrencyCodes) {
+  const errors = [];
+  const currencyFields = getCurrencyFields(items);
+  const totals = Object.fromEntries(currencyFields.map(currency => [currency, 0]));
+  const metadataWarnings = [];
+  let totalTokens = 0;
+
+  items.forEach(item => {
+    const count = toNumber(item.count);
+    const currencyTotal = currencyFields.reduce((sum, currency) => {
+      const value = toNumber(item[currency]);
+      totals[currency] += value;
+      return sum + value;
+    }, 0);
+
+    totalTokens += count;
+
+    if (count !== currencyTotal) {
+      errors.push(`${item.issuer || `row ${item.id}`}: count is ${count}, but currency total is ${currencyTotal}`);
+    }
+  });
+
+  currencyFields.forEach(currency => {
+    const currencyCode = currency.toUpperCase();
+    if (!knownCurrencyCodes.has(currencyCode) && totals[currency] > 0) {
+      metadataWarnings.push(`${currencyCode} has token data but no currencyInfo metadata in index.html`);
+    }
+  });
+
+  return { currencyFields, errors, metadataWarnings, totalTokens, totals };
+}
+
+try {
+  const html = fs.readFileSync(indexPath, 'utf8');
+  const items = extractDashboardData(html);
+  const knownCurrencyCodes = extractCurrencyInfoCodes(html);
+
+  if (!Array.isArray(items) || items.length === 0) {
+    fail('No EMT data entries found in index.html.');
+  } else {
+    const { currencyFields, errors, metadataWarnings, totalTokens, totals } = validateItems(items, knownCurrencyCodes);
+
+    if (currencyFields.length === 0) {
+      fail('No currency fields found in EMT dashboard data.');
+    }
+
+    if (errors.length > 0) {
+      fail('EMT token counts do not match per-currency totals.', errors);
+    }
+
+    metadataWarnings.forEach(warning => console.warn(`⚠️ ${warning}`));
+
+    if (process.exitCode !== 1) {
+      const visibleTotals = Object.entries(totals)
+        .filter(([, value]) => value > 0)
+        .map(([currency, value]) => `${currency.toUpperCase()}=${value}`)
+        .join(', ');
+
+      console.log(`✅ Validated ${items.length} EMT rows.`);
+      console.log(`✅ Total tokens: ${totalTokens}`);
+      console.log(`✅ Currency totals: ${visibleTotals}`);
+    }
+  }
+} catch (error) {
+  fail(error.message);
+}

--- a/update-data.js
+++ b/update-data.js
@@ -13,7 +13,7 @@ const NON_COMPLIANT_DATA_FILE = path.join(DATA_DIR, 'non-compliant.json');
 
 const SHEET_CONFIG = {
     snapshot: { label: 'Snapshot dates', range: 'snapshot!A1:B3' },
-    emt: { label: 'EMTs register', range: 'Jurisdiction!A1:L50', requireNumericId: true },
+    emt: { label: 'EMTs register', range: 'Jurisdiction!A1:Z100', requireNumericId: true },
     casps: { label: 'CASPs register', range: 'CASPs!A1:F150' },
     nonCompliant: { label: 'Non-compliant register', range: 'Non Compliant!A1:E150' }
 };
@@ -407,19 +407,51 @@ function formatDate(dateStr) {
     };
 }
 
+const EMT_STANDARD_HEADERS = new Set([
+    '#',
+    'Issuer (HQ)',
+    'Home State',
+    'Competent Authority',
+    'Authorised EMT(s)',
+    'Tokens'
+]);
+
+const CURRENCY_HEADER_KEY_ALIASES = {
+    euro: 'eur'
+};
+
+function currencyHeaderToKey(header) {
+    const normalizedHeader = header.trim().toLowerCase();
+    return CURRENCY_HEADER_KEY_ALIASES[normalizedHeader] || normalizedHeader;
+}
+
+function getEmtCurrencyHeaders(rows) {
+    const headers = new Set();
+
+    rows.forEach(row => {
+        Object.keys(row || {}).forEach(header => {
+            if (header && !EMT_STANDARD_HEADERS.has(header)) {
+                headers.add(header);
+            }
+        });
+    });
+
+    return Array.from(headers);
+}
+
 function convertToJsData(csvData) {
     const data = [];
+    const currencyHeaders = getEmtCurrencyHeaders(csvData);
 
     console.log('📋 CSV Headers:', Object.keys(csvData[0] || {}));
+    console.log('💱 Currency Headers:', currencyHeaders);
     console.log('📊 Processing', csvData.length, 'rows');
 
     csvData.forEach((row, index) => {
         console.log(`Row ${index + 1}:`, {
             id: row['#'],
             issuer: row['Issuer (HQ)'],
-            tokens: row['Tokens'],
-            euro: row['Euro'],
-            usd: row['USD']
+            tokens: row['Tokens']
         });
 
         if (row['#'] && row['Issuer (HQ)'] && row['Issuer (HQ)'] !== 'nan') {
@@ -429,14 +461,13 @@ function convertToJsData(csvData) {
                 state: row['Home State'] || '',
                 authority: row['Competent Authority'] || '',
                 tokens: row['Authorised EMT(s)'] || '',
-                count: parseNumber(row['Tokens']),
-                euro: parseNumber(row['Euro']),
-                usd: parseNumber(row['USD']),
-                czk: parseNumber(row['CZK']),
-                gbp: parseNumber(row['GBP']),
-                chf: parseNumber(row['CHF']),
-                pln: parseNumber(row['PLN'])
+                count: parseNumber(row['Tokens'])
             };
+
+            currencyHeaders.forEach(header => {
+                item[currencyHeaderToKey(header)] = parseNumber(row[header]);
+            });
+
             data.push(item);
             console.log('✅ Added:', item.issuer, 'with', item.count, 'tokens');
         }
@@ -507,6 +538,28 @@ function mapMemberState(code) {
     if (!code) return '';
     const trimmed = code.trim();
     return memberStateMap[trimmed.toUpperCase()] || trimmed;
+}
+
+function getCurrencyFieldsFromItems(items) {
+    const standardFields = new Set(['id', 'issuer', 'state', 'authority', 'tokens', 'count']);
+    const fields = new Set();
+
+    items.forEach(item => {
+        Object.keys(item || {}).forEach(key => {
+            if (!standardFields.has(key)) {
+                fields.add(key);
+            }
+        });
+    });
+
+    return Array.from(fields);
+}
+
+function calculateCurrencyTotals(items, currencyFields) {
+    return Object.fromEntries(currencyFields.map(currency => [
+        currency,
+        items.reduce((sum, item) => sum + (item[currency] || 0), 0)
+    ]));
 }
 
 function convertToNonCompliantData(csvData) {
@@ -644,22 +697,15 @@ function updateHtmlFile(newData, emtLastUpdated, nonCompliantEntries, caspsEntri
 
     // Log summary statistics
     const totalTokens = newData.reduce((sum, item) => sum + item.count, 0);
-    const euroTokens = newData.reduce((sum, item) => sum + item.euro, 0);
-    const usdTokens = newData.reduce((sum, item) => sum + item.usd, 0);
-    const gbpTokens = newData.reduce((sum, item) => sum + item.gbp, 0);
-    const czkTokens = newData.reduce((sum, item) => sum + item.czk, 0);
-    const chfTokens = newData.reduce((sum, item) => sum + item.chf, 0);
-    const plnTokens = newData.reduce((sum, item) => sum + item.pln, 0);
+    const currencyFields = getCurrencyFieldsFromItems(newData);
+    const currencyTotals = calculateCurrencyTotals(newData, currencyFields);
 
     console.log('📈 Summary Statistics:');
     console.log(`   Total Issuers: ${newData.length}`);
     console.log(`   Total Tokens: ${totalTokens}`);
-    console.log(`   EUR Tokens: ${euroTokens}`);
-    console.log(`   USD Tokens: ${usdTokens}`);
-    console.log(`   GBP Tokens: ${gbpTokens}`);
-    console.log(`   CZK Tokens: ${czkTokens}`);
-    console.log(`   CHF Tokens: ${chfTokens}`);
-    console.log(`   PLN Tokens: ${plnTokens}`);
+    Object.entries(currencyTotals).forEach(([currency, total]) => {
+        console.log(`   ${currency.toUpperCase()} Tokens: ${total}`);
+    });
     if (Array.isArray(nonCompliantEntries)) {
         console.log(`   Non-compliant entities: ${nonCompliantEntries.length}`);
     }


### PR DESCRIPTION
### Motivation

- Ensure the generated static dashboard is internally consistent by validating that per-issuer token `count` matches the sum of currency columns and by surfacing missing currency metadata before a deployment.
- Make the EMT CSV parsing resilient to additional currency columns and expanded sheet ranges so new currencies are automatically picked up.
- Improve UX for CASPs and Non‑Compliant lists by adding numbering, a "New only" toggle, summary info, and clearer currency badges.
- Automatically request a GitHub Pages rebuild after the dashboard is updated.

### Description

- Added a validation script at `scripts/validate-dashboard-data.js` and an npm script `validate:data` to parse `index.html`, detect currency columns, check that each row's `count` equals the sum of its currency columns, and warn about currency metadata mismatches.
- Updated the GitHub Actions workflow (`.github/workflows/update-dashboard.yml`) to grant `pages: write`, run `npm run validate:data` during the update flow, and trigger a GitHub Pages build via `gh api repos/${{ github.repository }}/pages/builds` when changes are pushed or on manual dispatch.
- Extended EMT sheet parsing in `update-data.js` to use the wider range `Jurisdiction!A1:Z100`, dynamically detect and normalize currency header names, populate currency fields on each item, and log currency totals instead of hard-coded columns.
- Updated `index.html` to: use unified currency keys and dynamic badge styling (`getCurrencyBadgeStyle` and `currencyBadgeStyles`), add sequence numbers to CASPs and Non‑Compliant tables, add a "New only" toggle and summary for non‑compliant entries, highlight new rows, and several dataset fixes/normalisations (currency fields, URLs, names, and authority text corrections).
- Documented the validation step in `README.md` and added the `validate:data` script to `package.json`.

### Testing

- Added CI coverage: the workflow now runs `npm run validate:data` as part of the dashboard update job (validation will cause the job to fail if inconsistencies are detected).
- Executed the new validator locally (`node scripts/validate-dashboard-data.js` / `npm run validate:data`) against the updated `index.html`, and it completed without errors.
- No unit test suite was present prior to this change; other automated checks remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a316fb704188327b6a5d8677b704a46)