### PR TITLE
Converge on standalone register pages; add summary cards and fix sticky headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
         node --check config.js
         node --check scripts/validate-dashboard-data.js
         node --check assets/js/mobile-menu.js
+        node --check assets/js/register-view.js
+
+    - name: Check sitemap lists the intent pages
+      run: |
+        for page in casp-tracker.html emt-tracker.html non-compliant-casps.html; do
+          grep -q "$page" sitemap.xml || { echo "sitemap missing $page"; exit 1; }
+          test -f "$page" || { echo "missing page $page"; exit 1; }
+        done
 
     - name: Check updater markers and data files
       # update-data.js patches the footer "Data as of" lines in index.html;

--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action Bot"
-        git add index.html data/ feed.xml
+        git add index.html data/ feed.xml sitemap.xml
         git status
         git commit -m "🤖 Auto-update dashboard data - $(date '+%Y-%m-%d %H:%M:%S UTC')" || {
           echo "No changes to commit"

--- a/about.html
+++ b/about.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About — DEA MiCAR Tracker</title>
+  <title>How the MiCAR Tracker works — data sources &amp; methodology | DEA</title>
+  <meta name="description" content="How the DEA MiCAR Tracker collects, filters and enriches ESMA interim MiCA register data for CASPs, EMT issuers and non-compliant entities, and how often it is updated.">
+  <link rel="canonical" href="https://micatracker.digital-euro-association.de/about.html">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev; object-src 'none'; base-uri 'self'; form-action 'self'">
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="stylesheet" href="styles/tailwind.css">
@@ -338,8 +340,18 @@
       </div>
 
       <div class="flex flex-col md:flex-row md:justify-between gap-8">
-        <nav>
-          <ul class="space-y-2 md:space-y-0 md:flex md:gap-6 text-sm">
+        <nav aria-label="Registers">
+          <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Registers</p>
+          <ul class="space-y-2 text-sm">
+            <li><a href="casp-tracker.html" class="hover:text-white font-semibold">CASP Tracker</a></li>
+            <li><a href="emt-tracker.html" class="hover:text-white font-semibold">EMT Tracker</a></li>
+            <li><a href="non-compliant-casps.html" class="hover:text-white font-semibold">Non-Compliant CASPs</a></li>
+            <li><a href="index.html" class="hover:text-white font-semibold">Full dashboard</a></li>
+          </ul>
+        </nav>
+        <nav aria-label="Legal">
+          <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Digital Euro Association</p>
+          <ul class="space-y-2 text-sm">
             <li><a href="https://home.digital-euro-association.de/legal-notice?hsLang=en"  target="_blank" rel="noopener" class="hover:text-white font-semibold">Legal Notice</a></li>
             <li><a href="https://home.digital-euro-association.de/privacy-policy-0?hsLang=en" target="_blank" rel="noopener" class="hover:text-white font-semibold">Privacy</a></li>
             <li><a href="https://home.digital-euro-association.de/code-of-conduct?hsLang=en"  target="_blank" rel="noopener" class="hover:text-white font-semibold">Code of Conduct</a></li>

--- a/assets/js/register-view.js
+++ b/assets/js/register-view.js
@@ -265,6 +265,57 @@
     }
   };
 
+  // ---- per-register summary cards --------------------------------------
+  // Rendered above the table. `extra` carries values that need a second
+  // dataset (e.g. the non-compliant count shown on the CASP page).
+  function uniqueCount(items, getKey) {
+    const seen = {};
+    items.forEach(function (i) {
+      const k = (getKey(i) || '').trim().toLowerCase();
+      if (k) seen[k] = 1;
+    });
+    return Object.keys(seen).length;
+  }
+
+  const SUMMARIES = {
+    casps: function (items, extra) {
+      return [
+        { title: 'Total Providers', value: items.length, subtitle: 'Registered CASP providers', icon: '🏢', color: 'kpi-teal' },
+        { title: 'Total Countries', value: uniqueCount(items, function (i) { return i.memberState; }), subtitle: 'Countries represented', icon: '🌍', color: 'kpi-blue' },
+        { title: 'Non-Compliant CASPs', value: (extra && extra.nonCompliantCount != null) ? extra.nonCompliantCount : '—', subtitle: 'Flagged providers', icon: '⚠️', color: 'kpi-red' }
+      ];
+    },
+    emt: function (items) {
+      const totalTokens = items.reduce(function (s, i) { return s + (Number(i.count) || 0); }, 0);
+      return [
+        { title: 'Total Issuers', value: items.length, subtitle: 'Active EMT providers', icon: '🏢', color: 'kpi-teal' },
+        { title: 'Total Tokens', value: totalTokens, subtitle: 'Authorised EMTs', icon: '🪙', color: 'kpi-blue' },
+        { title: 'Countries', value: uniqueCount(items, function (i) { return i.state; }), subtitle: 'Countries represented', icon: '🌍', color: 'kpi-orange' }
+      ];
+    },
+    nonCompliant: function (items) {
+      return [
+        { title: 'Flagged Entities', value: items.length, subtitle: 'Total non-compliant', icon: '⚠️', color: 'kpi-red' },
+        { title: 'New This Update', value: items.filter(function (i) { return i.isNew; }).length, subtitle: 'Recently added', icon: '⭐', color: 'kpi-blue' },
+        { title: 'Countries', value: uniqueCount(items, function (i) { return i.country; }), subtitle: 'Countries represented', icon: '🌍', color: 'kpi-orange' }
+      ];
+    }
+  };
+
+  function summaryHtml(cards) {
+    if (!cards || !cards.length) return '';
+    const cols = Math.min(cards.length, 4);
+    return '<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-' + cols + ' gap-6 mb-8 fade-in">' +
+      cards.map(function (c) {
+        return '<div class="kpi-card ' + c.color + ' p-6 rounded-2xl shadow-lg text-white card-hover">' +
+          '<div class="flex items-center justify-between"><div>' +
+          '<p class="text-sm opacity-90 font-medium">' + esc(c.title) + '</p>' +
+          '<p class="text-3xl font-bold mt-2">' + esc(c.value) + '</p>' +
+          '<p class="text-sm opacity-80 mt-1">' + esc(c.subtitle) + '</p>' +
+          '</div><div class="text-4xl opacity-80" aria-hidden="true">' + c.icon + '</div></div></div>';
+      }).join('') + '</div>';
+  }
+
   const cfg = CONFIGS[register];
   if (!cfg) { root.innerHTML = '<p class="text-red-700">Unknown register.</p>'; return; }
 
@@ -444,7 +495,23 @@
       return;
     }
     filtered = all.slice();
-    root.innerHTML = shellHtml();
+
+    // The CASP summary shows the non-compliant count, which lives in a
+    // separate file. Fetch it first (non-fatal) so the card renders with
+    // the real number; if it fails the card falls back to an em dash.
+    let extra = null;
+    if (register === 'casps') {
+      try {
+        const ncRes = await fetch('data/non-compliant.json', { cache: 'no-cache' });
+        if (ncRes.ok) {
+          const nc = await ncRes.json();
+          if (Array.isArray(nc)) extra = { nonCompliantCount: nc.length };
+        }
+      } catch (e) { /* non-fatal */ }
+    }
+
+    const cards = SUMMARIES[register] ? SUMMARIES[register](all, extra) : null;
+    root.innerHTML = summaryHtml(cards) + shellHtml();
     if (cfg.filters) populateFilters();
     wire();
     renderRows();

--- a/assets/js/register-view.js
+++ b/assets/js/register-view.js
@@ -1,0 +1,459 @@
+/*
+ * register-view.js — renders a single MiCA register (CASPs, EMT issuers, or
+ * non-compliant entities) into a mount point, with search, sorting, CSV/JSON
+ * export, freshness, and (for CASPs) country/service filters.
+ *
+ * Used by the standalone intent pages (casp-tracker.html, emt-tracker.html,
+ * non-compliant-casps.html). It is deliberately self-contained and does not
+ * touch the main dashboard's inline script, so the live index.html carries no
+ * risk from changes here. The country-flag map below is duplicated from
+ * index.html on purpose for isolation; consolidating both onto this module is
+ * tracked as future cleanup.
+ *
+ * Mount point: <div id="registerRoot" data-register="casps|emt|nonCompliant">
+ */
+(function () {
+  'use strict';
+
+  const root = document.getElementById('registerRoot');
+  if (!root) return;
+  const register = root.dataset.register;
+
+  // ---- helpers ----------------------------------------------------------
+  function esc(value) {
+    return String(value == null ? '' : value).replace(/[&<>"']/g, function (ch) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+    });
+  }
+
+  function safeHttpUrl(value) {
+    const url = String(value || '').trim();
+    return /^https?:\/\//i.test(url) ? url : '';
+  }
+
+  function debounce(fn, wait) {
+    let timer = null;
+    return function () {
+      const args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () { fn.apply(null, args); }, wait || 150);
+    };
+  }
+
+  function csvEscape(value) {
+    const str = String(value == null ? '' : value);
+    return /[",\n]/.test(str) ? '"' + str.replace(/"/g, '""') + '"' : str;
+  }
+
+  function downloadCsv(filename, columns, rows) {
+    if (!rows.length) return;
+    const header = columns.map(function (c) { return csvEscape(c.label); }).join(',');
+    const lines = rows.map(function (row) {
+      return columns.map(function (c) { return csvEscape(c.value(row)); }).join(',');
+    });
+    const blob = new Blob(['\uFEFF' + [header].concat(lines).join('\r\n')], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function formatSnapshotDate(value) {
+    if (!value) return '';
+    const parts = String(value).split(/[/\-.]/);
+    if (parts.length === 3) {
+      let day, month, year;
+      if (parts[0].length === 4) { year = parts[0]; month = parts[1]; day = parts[2]; }
+      else { day = parts[0]; month = parts[1]; year = parts[2]; }
+      const parsed = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+      if (!isNaN(parsed.getTime())) {
+        return parsed.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' });
+      }
+    }
+    return String(value);
+  }
+
+  const countryFlags = {
+    'Austria': '🇦🇹', 'Belgium': '🇧🇪', 'Bulgaria': '🇧🇬', 'Croatia': '🇭🇷', 'Cyprus': '🇨🇾',
+    'Czech Republic': '🇨🇿', 'Czechia': '🇨🇿', 'Denmark': '🇩🇰', 'Estonia': '🇪🇪', 'Finland': '🇫🇮',
+    'France': '🇫🇷', 'Germany': '🇩🇪', 'Greece': '🇬🇷', 'Hungary': '🇭🇺', 'Ireland': '🇮🇪',
+    'Italy': '🇮🇹', 'Latvia': '🇱🇻', 'Lithuania': '🇱🇹', 'Luxembourg': '🇱🇺', 'Malta': '🇲🇹',
+    'Netherlands': '🇳🇱', 'Poland': '🇵🇱', 'Portugal': '🇵🇹', 'Romania': '🇷🇴', 'Slovakia': '🇸🇰',
+    'Slovenia': '🇸🇮', 'Spain': '🇪🇸', 'Sweden': '🇸🇪', 'Iceland': '🇮🇸', 'Liechtenstein': '🇱🇮',
+    'Norway': '🇳🇴', 'United Kingdom': '🇬🇧', 'UK': '🇬🇧'
+  };
+  function flag(country) { return countryFlags[country] || '🏳️'; }
+
+  const currencyInfo = {
+    'EUR': { symbol: '💶', color: 'orange' }, 'USD': { symbol: '💵', color: 'coral' },
+    'GBP': { symbol: '💷', color: 'purple' }, 'CZK': { symbol: '🇨🇿', color: 'blue' },
+    'CHF': { symbol: '🇨🇭', color: 'red' }, 'SEK': { symbol: '🇸🇪', color: 'yellow' },
+    'PLN': { symbol: '🇵🇱', color: 'red' }, 'RON': { symbol: '🇷🇴', color: 'yellow' },
+    'NOK': { symbol: '🇳🇴', color: 'teal' }, 'DKK': { symbol: '🇩🇰', color: 'blue' },
+    'HUF': { symbol: '🇭🇺', color: 'green' }, 'HKD': { symbol: '🇭🇰', color: 'green' }
+  };
+  const currencyBadgeStyles = {
+    orange: 'background-color: #ffedd5; color: #c2410c;', coral: 'background-color: #ffe4e6; color: #be123c;',
+    purple: 'background-color: #f3e8ff; color: #7e22ce;', blue: 'background-color: #dbeafe; color: #1d4ed8;',
+    green: 'background-color: #dcfce7; color: #15803d;', red: 'background-color: #fee2e2; color: #b91c1c;',
+    yellow: 'background-color: #fef9c3; color: #a16207;', teal: 'background-color: #ccfbf1; color: #0f766e;'
+  };
+  function currencyBadgeStyle(code) {
+    const color = (currencyInfo[code] && currencyInfo[code].color) || 'green';
+    return currencyBadgeStyles[color] || currencyBadgeStyles.green;
+  }
+  const EMT_STANDARD = { id: 1, issuer: 1, state: 1, authority: 1, tokens: 1, count: 1 };
+  function currencyFields(items) {
+    const set = {};
+    items.forEach(function (item) {
+      Object.keys(item || {}).forEach(function (k) { if (!EMT_STANDARD[k]) set[k] = 1; });
+    });
+    return Object.keys(set);
+  }
+
+  // ---- per-register configuration --------------------------------------
+  const CONFIGS = {
+    casps: {
+      dataUrl: 'data/casps.json', jsonHref: 'data/casps.json', jsonName: 'micar-casps.json',
+      csvName: 'micar-casps.csv', snapshotKey: 'caspsSnapshotDate', theme: 'teal',
+      searchPlaceholder: 'Search CASPs, countries, services…',
+      searchLabel: 'Search CASPs by name, country, authority, service, or website',
+      caption: 'Crypto-Asset Service Providers registered under MiCAR',
+      filters: true,
+      columns: [
+        { label: '#', width: '4%' },
+        { label: 'CASP', width: '24%', sort: 'name' },
+        { label: 'Country', width: '16%', sort: 'memberState' },
+        { label: 'Competent Authority', width: '12%', sort: 'authority' },
+        { label: 'Services', width: '28%', cls: 'services-cell' },
+        { label: 'Websites', width: '16%' }
+      ],
+      matches: function (item, term) {
+        return (item.name || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.memberState || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.authority || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.services || []).join(' ').toLowerCase().indexOf(term) !== -1 ||
+          (item.websites || []).join(' ').toLowerCase().indexOf(term) !== -1;
+      },
+      row: function (item, i) {
+        const services = (item.services || []).map(function (s) {
+          return '<span class="service-badge px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium">' + esc(s) + '</span>';
+        }).join(' ');
+        const sites = (item.websites && item.websites.length)
+          ? item.websites.map(function (site) {
+            const u = safeHttpUrl(site);
+            return u
+              ? '<a href="' + esc(u) + '" target="_blank" rel="noopener" class="casps-website-link block text-sm text-blue-600 underline">' + esc(site) + '</a>'
+              : '<span class="casps-website-link block text-sm text-gray-600">' + esc(site) + '</span>';
+          }).join('')
+          : '<span class="text-xs text-gray-500">Not provided</span>';
+        return '<tr class="border-b hover:bg-gradient-to-r hover:from-teal-200 hover:to-blue-200 transition-all duration-200">' +
+          '<td class="p-4 text-sm font-semibold text-gray-500">' + (i + 1) + '</td>' +
+          '<td class="p-4"><p class="text-gray-900 font-semibold">' + esc(item.name || 'N/A') + '</p></td>' +
+          '<td class="p-4"><span class="casps-country-badge px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.memberState) + '</span> ' + esc(item.memberState || 'Unknown') + '</span></td>' +
+          '<td class="p-4 text-gray-600 text-sm casps-authority-cell">' + esc(item.authority || '—') + '</td>' +
+          '<td class="p-4 services-cell"><div class="service-badges">' + (services || '<span class="text-xs text-gray-500">Not specified</span>') + '</div></td>' +
+          '<td class="p-4"><div class="space-y-1">' + sites + '</div></td></tr>';
+      },
+      csv: [
+        { label: 'CASP', value: function (r) { return r.name; } },
+        { label: 'Country', value: function (r) { return r.memberState; } },
+        { label: 'Competent Authority', value: function (r) { return r.authority; } },
+        { label: 'Services', value: function (r) { return (r.services || []).join('; '); } },
+        { label: 'Websites', value: function (r) { return (r.websites || []).join('; '); } }
+      ]
+    },
+
+    emt: {
+      dataUrl: 'data/emts.json', jsonHref: 'data/emts.json', jsonName: 'micar-emts.json',
+      csvName: 'micar-emts.csv', snapshotKey: 'emtSnapshotDate', theme: 'teal',
+      searchPlaceholder: 'Search issuers, countries, tokens…',
+      searchLabel: 'Search EMT issuers by name, country, authority, or token',
+      caption: 'Electronic Money Token issuers authorised under MiCAR',
+      filters: false,
+      columns: [
+        { label: 'Issuer', width: '26%', sort: 'issuer' },
+        { label: 'Country', width: '20%', sort: 'state' },
+        { label: 'Authority', width: '18%', sort: 'authority' },
+        { label: 'Tokens', width: '18%' },
+        { label: 'Count', width: '8%', sort: 'count', align: 'center' },
+        { label: 'Currencies', width: '10%', align: 'center' }
+      ],
+      matches: function (item, term) {
+        return (item.issuer || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.state || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.authority || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.tokens || '').toLowerCase().indexOf(term) !== -1;
+      },
+      row: function (item, i, all) {
+        const fields = currencyFields(all);
+        const badges = fields.filter(function (c) { return item[c] > 0; }).map(function (c) {
+          const code = c.toUpperCase();
+          return '<span class="px-2 py-1 rounded text-xs font-semibold" style="' + currencyBadgeStyle(code) + '">' + esc(code) + '</span>';
+        }).join(' ');
+        const countCls = item.count > 1 ? 'bg-green-100 text-green-800' : (item.count === 1 ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-600');
+        return '<tr class="border-b hover:bg-gradient-to-r hover:from-teal-200 hover:to-blue-200 transition-all duration-200 ' + (i % 2 === 0 ? 'bg-gray-50' : 'bg-white') + '">' +
+          '<td class="p-4"><div class="font-semibold text-gray-800">' + esc(item.issuer) + '</div></td>' +
+          '<td class="p-4"><span class="px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.state) + '</span> ' + esc(item.state) + '</span></td>' +
+          '<td class="p-4 text-gray-600 text-sm">' + esc(item.authority) + '</td>' +
+          '<td class="p-4"><div class="text-sm text-gray-800 font-mono">' + esc(item.tokens || 'N/A') + '</div></td>' +
+          '<td class="p-4 text-center"><span class="px-3 py-1 rounded-full text-sm font-bold ' + countCls + '">' + esc(item.count) + '</span></td>' +
+          '<td class="p-4 text-center"><div class="flex justify-center space-x-1">' + badges + '</div></td></tr>';
+      },
+      csvColumns: function (all) {
+        const base = [
+          { label: 'Issuer', value: function (r) { return r.issuer; } },
+          { label: 'Country', value: function (r) { return r.state; } },
+          { label: 'Authority', value: function (r) { return r.authority; } },
+          { label: 'Tokens', value: function (r) { return r.tokens; } },
+          { label: 'Count', value: function (r) { return r.count; } }
+        ];
+        currencyFields(all).forEach(function (c) {
+          base.push({ label: c.toUpperCase(), value: function (r) { return r[c] || 0; } });
+        });
+        return base;
+      }
+    },
+
+    nonCompliant: {
+      dataUrl: 'data/non-compliant.json', jsonHref: 'data/non-compliant.json', jsonName: 'micar-non-compliant.json',
+      csvName: 'micar-non-compliant.csv', snapshotKey: 'caspsSnapshotDate', theme: 'red',
+      searchPlaceholder: 'Search entities, authorities, websites…',
+      searchLabel: 'Search non-compliant entities by name, country, authority, or website',
+      caption: 'Entities flagged as non-compliant by European regulators',
+      filters: false,
+      columns: [
+        { label: '#', width: '5%' },
+        { label: 'Entity Name', width: '25%', sort: 'entity' },
+        { label: 'Country', width: '14%', sort: 'country' },
+        { label: 'Regulatory Authority', width: '20%', sort: 'authority' },
+        { label: 'Websites', width: '26%' },
+        { label: 'Status', width: '10%', sort: 'isNew', align: 'center' }
+      ],
+      matches: function (item, term) {
+        return (item.entity || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.country || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.authority || '').toLowerCase().indexOf(term) !== -1 ||
+          (item.websites || []).some(function (w) { return w.toLowerCase().indexOf(term) !== -1; });
+      },
+      row: function (item, i) {
+        const bg = item.isNew ? 'bg-blue-50' : (i % 2 === 0 ? 'bg-gray-50' : 'bg-white');
+        // Websites of flagged entities are rendered as TEXT, never links.
+        const sites = (item.websites || []).map(function (w) {
+          return '<div class="text-xs text-blue-600 font-mono bg-blue-50 px-2 py-1 rounded">' + esc(w) + '</div>';
+        }).join('');
+        const newBadge = item.isNew ? '<span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold text-blue-700 bg-blue-100"><i class="fas fa-star text-blue-500 mr-1" aria-hidden="true"></i>New</span>' : '';
+        return '<tr class="border-b hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 transition-all duration-200 ' + bg + '">' +
+          '<td class="p-4 text-sm font-semibold text-gray-500">' + (i + 1) + '</td>' +
+          '<td class="p-4"><div class="font-semibold text-gray-800 flex items-center"><span>' + esc(item.entity) + '</span>' + newBadge + '</div></td>' +
+          '<td class="p-4"><span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.country) + '</span> ' + esc(item.country) + '</span></td>' +
+          '<td class="p-4 text-gray-600 text-sm">' + esc(item.authority) + '</td>' +
+          '<td class="p-4"><div class="space-y-1">' + sites + '</div></td>' +
+          '<td class="p-4 text-center"><span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-bold" title="Flagged"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Flagged</span></span></td></tr>';
+      },
+      csv: [
+        { label: 'Entity', value: function (r) { return r.entity; } },
+        { label: 'Country', value: function (r) { return r.country; } },
+        { label: 'Regulatory Authority', value: function (r) { return r.authority; } },
+        { label: 'Websites', value: function (r) { return (r.websites || []).join('; '); } },
+        { label: 'New', value: function (r) { return r.isNew ? 'yes' : 'no'; } }
+      ]
+    }
+  };
+
+  const cfg = CONFIGS[register];
+  if (!cfg) { root.innerHTML = '<p class="text-red-700">Unknown register.</p>'; return; }
+
+  // ---- state ------------------------------------------------------------
+  let all = [];
+  let filtered = [];
+  const sortState = { key: null, dir: 1 };
+
+  function sortRows(rows) {
+    if (!sortState.key) return rows;
+    const key = sortState.key, dir = sortState.dir;
+    return rows.slice().sort(function (a, b) {
+      const va = a[key], vb = b[key];
+      if (typeof va === 'number' || typeof vb === 'number' || typeof va === 'boolean' || typeof vb === 'boolean') {
+        return (Number(va || 0) - Number(vb || 0)) * dir;
+      }
+      return String(va || '').localeCompare(String(vb || ''), 'en', { sensitivity: 'base' }) * dir;
+    });
+  }
+
+  function applyFilters() {
+    const term = (document.getElementById('rvSearch').value || '').trim().toLowerCase();
+    const country = cfg.filters ? (document.getElementById('rvCountry').value || '') : '';
+    const service = cfg.filters ? (document.getElementById('rvService').value || '') : '';
+    filtered = all.filter(function (item) {
+      const matchesSearch = !term || cfg.matches(item, term);
+      const matchesCountry = !country || (item.memberState || '') === country;
+      const matchesService = !service || (item.services || []).indexOf(service) !== -1;
+      return matchesSearch && matchesCountry && matchesService;
+    });
+    renderRows();
+  }
+
+  function renderRows() {
+    const rows = sortRows(filtered);
+    const tbody = document.getElementById('rvTbody');
+    const noResults = document.getElementById('rvNoResults');
+    const count = document.getElementById('rvCount');
+    if (count) count.textContent = rows.length + (rows.length === 1 ? ' entry' : ' entries');
+    if (!rows.length) {
+      tbody.innerHTML = '';
+      noResults.classList.remove('hidden');
+      return;
+    }
+    noResults.classList.add('hidden');
+    tbody.innerHTML = rows.map(function (item, i) { return cfg.row(item, i, all); }).join('');
+  }
+
+  function csvColumns() {
+    return cfg.csvColumns ? cfg.csvColumns(all) : cfg.csv;
+  }
+
+  // ---- markup -----------------------------------------------------------
+  function controlsHtml() {
+    const filterSelects = cfg.filters
+      ? '<select id="rvCountry" aria-label="Filter by country" class="search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent"><option value="">All countries</option></select>' +
+        '<select id="rvService" aria-label="Filter by service" class="search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent"><option value="">All services</option></select>'
+      : '';
+    const dlBtnColor = cfg.theme === 'red' ? 'bg-red-600 hover:bg-red-700' : 'bg-teal-600 hover:bg-teal-700';
+    const jsonColor = cfg.theme === 'red' ? 'bg-red-100 text-red-800 hover:bg-red-200' : 'bg-teal-100 text-teal-800 hover:bg-teal-200';
+    const ring = cfg.theme === 'red' ? 'focus:ring-red-500' : 'focus:ring-teal-500';
+    return '<div class="flex flex-wrap items-center gap-3 mb-6">' +
+      filterSelects +
+      '<div class="relative">' +
+      '<input type="text" id="rvSearch" placeholder="' + esc(cfg.searchPlaceholder) + '" aria-label="' + esc(cfg.searchLabel) + '" class="search-input pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:ring-2 ' + ring + ' focus:border-transparent w-64">' +
+      '<i class="fas fa-search absolute left-3 top-3 text-gray-400" aria-hidden="true"></i>' +
+      '</div>' +
+      '<button id="rvClear" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"><i class="fas fa-times mr-1" aria-hidden="true"></i>Clear</button>' +
+      '<div class="flex items-center gap-3">' +
+      '<span class="text-sm text-gray-500">Download:</span>' +
+      '<button id="rvCsv" class="px-3 py-2 text-sm text-white rounded-lg transition-colors whitespace-nowrap ' + dlBtnColor + '"><i class="fas fa-download mr-1" aria-hidden="true"></i>CSV</button>' +
+      '<a href="' + cfg.jsonHref + '" download="' + cfg.jsonName + '" class="px-3 py-2 text-sm rounded-lg transition-colors whitespace-nowrap font-semibold ' + jsonColor + '">JSON</a>' +
+      '</div></div>';
+  }
+
+  function tableHtml() {
+    const cols = cfg.columns.map(function (c) { return '<col style="width: ' + c.width + ';">'; }).join('');
+    const ths = cfg.columns.map(function (c) {
+      const align = c.align === 'center' ? 'text-center' : 'text-left';
+      if (c.sort) {
+        return '<th scope="col" aria-sort="none" data-sort-key="' + c.sort + '" class="' + align + ' p-4 font-semibold text-gray-700"><button type="button" class="sort-button">' + esc(c.label) + '<span class="sort-indicator" aria-hidden="true"></span></button></th>';
+      }
+      return '<th scope="col" class="' + align + ' p-4 font-semibold text-gray-700' + (c.cls ? ' ' + c.cls : '') + '">' + esc(c.label) + '</th>';
+    }).join('');
+    const tableCls = register === 'casps' ? 'data-table casps-data-table w-full' : 'data-table w-full';
+    return '<div class="data-table-container"><table class="' + tableCls + '">' +
+      '<caption class="sr-only">' + esc(cfg.caption) + '</caption>' +
+      '<colgroup>' + cols + '</colgroup>' +
+      '<thead class="sticky-table-header ' + cfg.theme + '"><tr class="bg-gradient-to-r ' + (cfg.theme === 'red' ? 'from-red-50 to-orange-50' : 'from-teal-50 to-blue-50') + '">' + ths + '</tr></thead>' +
+      '<tbody id="rvTbody"></tbody></table></div>' +
+      '<div id="rvNoResults" class="hidden text-center py-8 text-gray-500"><i class="fas fa-search text-4xl mb-4" aria-hidden="true"></i><p class="text-lg">No results found.</p></div>';
+  }
+
+  function shellHtml() {
+    return '<div class="bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6">' +
+      '<p id="rvCount" class="text-sm text-gray-500 mb-4"></p>' +
+      controlsHtml() + tableHtml() + '</div>';
+  }
+
+  function wireSort() {
+    const headers = root.querySelectorAll('th[data-sort-key]');
+    headers.forEach(function (th) {
+      const button = th.querySelector('.sort-button');
+      if (!button) return;
+      button.addEventListener('click', function () {
+        const key = th.dataset.sortKey;
+        if (sortState.key === key) sortState.dir = -sortState.dir;
+        else { sortState.key = key; sortState.dir = 1; }
+        headers.forEach(function (h) {
+          const active = h === th;
+          h.setAttribute('aria-sort', active ? (sortState.dir === 1 ? 'ascending' : 'descending') : 'none');
+          const ind = h.querySelector('.sort-indicator');
+          if (ind) ind.textContent = active ? (sortState.dir === 1 ? '▲' : '▼') : '';
+        });
+        renderRows();
+      });
+    });
+  }
+
+  function populateFilters() {
+    const countrySel = document.getElementById('rvCountry');
+    const serviceSel = document.getElementById('rvService');
+    if (countrySel) {
+      const countries = {};
+      all.forEach(function (i) { const c = (i.memberState || '').trim(); if (c) countries[c] = 1; });
+      countrySel.innerHTML = '<option value="">All countries</option>' +
+        Object.keys(countries).sort().map(function (c) { return '<option value="' + esc(c) + '">' + esc(c) + '</option>'; }).join('');
+    }
+    if (serviceSel) {
+      const services = {};
+      all.forEach(function (i) { (i.services || []).forEach(function (s) { s = s.trim(); if (s) services[s] = 1; }); });
+      serviceSel.innerHTML = '<option value="">All services</option>' +
+        Object.keys(services).sort().map(function (s) { return '<option value="' + esc(s) + '">' + esc(s) + '</option>'; }).join('');
+    }
+  }
+
+  function wire() {
+    const debounced = debounce(applyFilters, 150);
+    document.getElementById('rvSearch').addEventListener('input', debounced);
+    document.getElementById('rvClear').addEventListener('click', function () {
+      document.getElementById('rvSearch').value = '';
+      if (cfg.filters) { document.getElementById('rvCountry').value = ''; document.getElementById('rvService').value = ''; }
+      applyFilters();
+    });
+    if (cfg.filters) {
+      document.getElementById('rvCountry').addEventListener('change', applyFilters);
+      document.getElementById('rvService').addEventListener('change', applyFilters);
+    }
+    document.getElementById('rvCsv').addEventListener('click', function () {
+      downloadCsv(cfg.csvName, csvColumns(), sortRows(filtered));
+    });
+    wireSort();
+  }
+
+  function setFreshness(snapshot) {
+    const el = document.getElementById('rvFreshness');
+    if (!el || !snapshot) return;
+    const parts = [];
+    const d = formatSnapshotDate(snapshot[cfg.snapshotKey] || snapshot.emtSnapshotDate || snapshot.caspsSnapshotDate);
+    if (d) parts.push('Register snapshot: ' + d);
+    if (snapshot.lastUpdated) {
+      const u = new Date(snapshot.lastUpdated);
+      if (!isNaN(u.getTime())) parts.push('last checked ' + u.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }));
+    }
+    if (parts.length) el.textContent = parts.join(' · ');
+  }
+
+  // ---- boot -------------------------------------------------------------
+  async function boot() {
+    try {
+      const res = await fetch(cfg.dataUrl, { cache: 'no-cache' });
+      if (!res.ok) throw new Error(cfg.dataUrl + ': HTTP ' + res.status);
+      all = await res.json();
+      if (!Array.isArray(all)) throw new Error('unexpected data shape');
+    } catch (e) {
+      root.innerHTML = '<div class="rounded-2xl bg-red-50 border border-red-200 p-4 text-red-800 text-sm" role="alert">Could not load the register data. Please refresh the page; if the problem persists the data file may be temporarily unavailable.</div>';
+      return;
+    }
+    filtered = all.slice();
+    root.innerHTML = shellHtml();
+    if (cfg.filters) populateFilters();
+    wire();
+    renderRows();
+    // Freshness (non-fatal)
+    fetch('data/snapshot.json', { cache: 'no-cache' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (s) { if (s) setFreshness(s); })
+      .catch(function () {});
+  }
+
+  boot();
+})();

--- a/assets/js/register-view.js
+++ b/assets/js/register-view.js
@@ -305,7 +305,7 @@
   function summaryHtml(cards) {
     if (!cards || !cards.length) return '';
     const cols = Math.min(cards.length, 4);
-    return '<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-' + cols + ' gap-6 mb-8 fade-in">' +
+    return '<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-' + cols + ' gap-6 mb-8">' +
       cards.map(function (c) {
         return '<div class="kpi-card ' + c.color + ' p-6 rounded-2xl shadow-lg text-white card-hover">' +
           '<div class="flex items-center justify-between"><div>' +
@@ -322,6 +322,9 @@
   // ---- state ------------------------------------------------------------
   let all = [];
   let filtered = [];
+  // Cross-dataset values that stay constant as the register is filtered
+  // (e.g. the non-compliant count shown on the CASP summary).
+  let extraSummary = null;
   const sortState = { key: null, dir: 1 };
 
   function sortRows(rows) {
@@ -349,7 +352,16 @@
     renderRows();
   }
 
+  // Summary cards reflect the current filtered view (Total Providers /
+  // Countries track the filter); cross-dataset values come from extraSummary.
+  function renderSummary() {
+    const mount = document.getElementById('rvSummary');
+    if (!mount || !SUMMARIES[register]) return;
+    mount.innerHTML = summaryHtml(SUMMARIES[register](filtered, extraSummary));
+  }
+
   function renderRows() {
+    renderSummary();
     const rows = sortRows(filtered);
     const tbody = document.getElementById('rvTbody');
     const noResults = document.getElementById('rvNoResults');
@@ -499,22 +511,20 @@
     // The CASP summary shows the non-compliant count, which lives in a
     // separate file. Fetch it first (non-fatal) so the card renders with
     // the real number; if it fails the card falls back to an em dash.
-    let extra = null;
     if (register === 'casps') {
       try {
         const ncRes = await fetch('data/non-compliant.json', { cache: 'no-cache' });
         if (ncRes.ok) {
           const nc = await ncRes.json();
-          if (Array.isArray(nc)) extra = { nonCompliantCount: nc.length };
+          if (Array.isArray(nc)) extraSummary = { nonCompliantCount: nc.length };
         }
       } catch (e) { /* non-fatal */ }
     }
 
-    const cards = SUMMARIES[register] ? SUMMARIES[register](all, extra) : null;
-    root.innerHTML = summaryHtml(cards) + shellHtml();
+    root.innerHTML = '<div id="rvSummary"></div>' + shellHtml();
     if (cfg.filters) populateFilters();
     wire();
-    renderRows();
+    renderRows(); // also renders the summary from the (initially full) view
     // Freshness (non-fatal)
     fetch('data/snapshot.json', { cache: 'no-cache' })
       .then(function (r) { return r.ok ? r.json() : null; })

--- a/assets/js/register-view.js
+++ b/assets/js/register-view.js
@@ -455,5 +455,16 @@
       .catch(function () {});
   }
 
+  // Track the site header height (it shrinks on scroll) so the sticky
+  // column headers pin just below it - same mechanism as index.html.
+  const siteHeaderEl = document.querySelector('.header-sticky');
+  if (siteHeaderEl && 'ResizeObserver' in window) {
+    const setSiteHeaderHeight = function () {
+      document.documentElement.style.setProperty('--site-header-height', siteHeaderEl.offsetHeight + 'px');
+    };
+    setSiteHeaderHeight();
+    new ResizeObserver(setSiteHeaderHeight).observe(siteHeaderEl, { box: 'border-box' });
+  }
+
   boot();
 })();

--- a/casp-tracker.html
+++ b/casp-tracker.html
@@ -75,10 +75,56 @@
         <a href="non-compliant-casps.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant</a>
         <a href="about.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-circle-info mr-2" aria-hidden="true"></i>About</a>
       </nav>
+      <div class="md:hidden flex items-center hamburger-only">
+        <button id="mobile-menu-button"
+                type="button"
+                class="hamburger-button text-white hover:text-sky-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white"
+                aria-controls="mobile-menu"
+                aria-expanded="false"
+                aria-label="Open main menu">
+          <svg id="hamburger-icon" class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <svg id="close-icon" class="h-6 w-6 hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
     </div>
     </div>
     </div>
     </header>
+
+    <div id="mobile-menu-overlay" class="mobile-menu-overlay fixed inset-0 hidden" aria-hidden="true"></div>
+
+    <div id="mobile-menu" class="mobile-menu-container hidden">
+      <div class="mobile-menu-panel p-4">
+        <nav class="flex flex-col mobile-menu-list" aria-label="Mobile navigation">
+          <a href="index.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-chart-pie"></i></span>
+            <span class="mobile-menu-text">Overview</span>
+          </a>
+          <a href="emt-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-table"></i></span>
+            <span class="mobile-menu-text">EMTs</span>
+          </a>
+          <a href="casp-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-building-columns"></i></span>
+            <span class="mobile-menu-text">CASPs</span>
+          </a>
+          <a href="non-compliant-casps.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-exclamation-triangle"></i></span>
+            <span class="mobile-menu-text">Non-Compliant</span>
+          </a>
+          <a href="about.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-circle-info"></i></span>
+            <span class="mobile-menu-text">About</span>
+          </a>
+        </nav>
+      </div>
+    </div>
 
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
     <section class="mb-8 text-white">
@@ -146,6 +192,15 @@
     </footer>
     <!-- ==== DEA FOOTER END ==== -->
 
+    <script>
+      window.addEventListener('scroll', function () {
+        var header = document.querySelector('.header-sticky');
+        if (!header) return;
+        if (window.scrollY > 20) header.classList.add('shrink');
+        else header.classList.remove('shrink');
+      });
+    </script>
+    <script src="assets/js/mobile-menu.js" defer></script>
     <script src="assets/js/register-view.js" defer></script>
     <script>
       document.addEventListener('DOMContentLoaded', function () {

--- a/casp-tracker.html
+++ b/casp-tracker.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev; object-src 'none'; base-uri 'self'; form-action 'self'">
+    <title>CASP Tracker — Search MiCA-Authorised Crypto-Asset Service Providers</title>
+    <meta name="description" content="Search MiCA-authorised Crypto-Asset Service Providers (CASPs) from the ESMA register. View CASPs by country, competent authority, services and website. Updated weekly by the Digital Euro Association. Free CSV/JSON download.">
+    <link rel="canonical" href="https://micatracker.digital-euro-association.de/casp-tracker.html">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://micatracker.digital-euro-association.de/casp-tracker.html">
+    <meta property="og:title" content="CASP Tracker — Search MiCA-Authorised Crypto-Asset Service Providers">
+    <meta property="og:description" content="Search MiCA-authorised Crypto-Asset Service Providers from the ESMA register, by country, competent authority, services and website. Updated weekly.">
+    <meta property="og:image" content="https://micatracker.digital-euro-association.de/cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="CASP Tracker — Search MiCA-Authorised Crypto-Asset Service Providers">
+    <meta name="twitter:description" content="Search MiCA-authorised Crypto-Asset Service Providers from the ESMA register, by country, competent authority, services and website. Updated weekly.">
+    <meta name="twitter:image" content="https://micatracker.digital-euro-association.de/cover.png">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="alternate" type="application/rss+xml" title="MiCAR Tracker register updates" href="feed.xml">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      "name": "MiCA-authorised Crypto-Asset Service Providers (CASPs)",
+      "description": "Crypto-Asset Service Providers authorised under the EU Markets in Crypto-Assets Regulation (MiCAR), derived from the ESMA interim MiCA register. Includes country, competent authority, services and website.",
+      "url": "https://micatracker.digital-euro-association.de/casp-tracker.html",
+      "keywords": ["CASP", "MiCA", "MiCAR", "crypto-asset service provider", "ESMA", "crypto licence"],
+      "creator": { "@type": "Organization", "name": "Digital Euro Association", "url": "https://digital-euro-association.de" },
+      "isBasedOn": "https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister",
+      "distribution": [
+        { "@type": "DataDownload", "encodingFormat": "application/json", "contentUrl": "https://micatracker.digital-euro-association.de/data/casps.json" }
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        { "@type": "Question", "name": "What is a CASP under MiCAR?", "acceptedAnswer": { "@type": "Answer", "text": "A CASP is a Crypto-Asset Service Provider authorised to provide crypto-asset services under the EU Markets in Crypto-Assets Regulation (MiCA/MiCAR)." } },
+        { "@type": "Question", "name": "Where does the CASP Tracker data come from?", "acceptedAnswer": { "@type": "Answer", "text": "The CASP Tracker uses public ESMA interim MiCA register data and presents it in a clearer, searchable format." } },
+        { "@type": "Question", "name": "How often is the CASP Tracker updated?", "acceptedAnswer": { "@type": "Answer", "text": "It is updated weekly based on the latest processed ESMA register data." } },
+        { "@type": "Question", "name": "Can I use this instead of the official ESMA register?", "acceptedAnswer": { "@type": "Answer", "text": "No. The tracker is a first-look tool. Verify formal authorisation status against ESMA or the relevant national competent authority." } }
+      ]
+    }
+    </script>
+    <link rel="stylesheet" href="styles/tailwind.css">
+    <link rel="stylesheet" href="styles/site.css">
+    <link rel="stylesheet" href="assets/vendor/inter/inter.css">
+    <link rel="stylesheet" href="assets/vendor/fontawesome/css/all.min.css">
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="dbd82f5d-689a-452f-9fff-fba85b9de507"></script>
+</head>
+<body class="main-bg">
+    <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-900 focus:font-semibold focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-lg">Skip to main content</a>
+    <header class="header-sticky shadow-2xl">
+    <div class="max-w-7xl mx-auto px-6 py-6">
+    <div class="flex items-center justify-between flex-wrap header-content">
+    <div class="flex items-center space-x-6 mb-4 md:mb-0">
+        <a href="index.html" class="inline-flex items-center" aria-label="Return to the dashboard">
+        <img src="DEA%20logo%20white.png" alt="DEA Logo" class="logo-container">
+        </a>
+        <div class="flex items-center">
+            <h1 class="text-[1.8rem] md:text-[2.2rem] font-bold text-white mb-0 leading-tight">
+                <span class="text-sky-100">MiCAR</span>
+                <span class="text-sky-50">Tracker</span>
+            </h1>
+        </div>
+    </div>
+    <div class="flex items-center gap-3 header-actions">
+      <nav class="hidden md:flex items-center nav-buttons" aria-label="Main navigation">
+        <a href="index.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-chart-pie mr-2" aria-hidden="true"></i>Overview</a>
+        <a href="emt-tracker.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-table mr-2" aria-hidden="true"></i>EMTs</a>
+        <a href="casp-tracker.html" class="tab-button tab-active px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-building-columns mr-2" aria-hidden="true"></i>CASPs</a>
+        <a href="non-compliant-casps.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant</a>
+        <a href="about.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-circle-info mr-2" aria-hidden="true"></i>About</a>
+      </nav>
+    </div>
+    </div>
+    </div>
+    </header>
+
+    <main id="main" class="max-w-7xl mx-auto px-6 py-8">
+    <section class="mb-8 text-white">
+    <h2 class="text-2xl md:text-3xl font-bold mb-3">CASP Tracker</h2>
+    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    Search <strong>Crypto-Asset Service Providers (CASPs)</strong> authorised under the EU's Markets in Crypto-Assets Regulation (MiCA / MiCAR), using public data from the ESMA interim MiCA register. View registered CASPs by country, competent authority, the services they provide and their website. Updated weekly by the Digital Euro Association; download the full list as CSV or JSON.
+    </p>
+    <p id="rvFreshness" class="text-sm text-blue-100 mt-3"></p>
+    </section>
+
+    <div id="registerRoot" data-register="casps">
+    <div class="rounded-2xl bg-white bg-opacity-90 p-4 text-gray-700 text-sm">Loading CASP register&hellip;</div>
+    </div>
+
+    <section class="mt-10 bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 md:p-8 text-gray-700">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4">CASP Tracker FAQ</h2>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">What is a CASP under MiCAR?</h3>
+    <p class="mt-1 leading-relaxed">A CASP is a Crypto-Asset Service Provider authorised to provide crypto-asset services — such as custody, exchange, execution or transfer — under the EU Markets in Crypto-Assets Regulation.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">Where does the CASP Tracker data come from?</h3>
+    <p class="mt-1 leading-relaxed">It uses public data from the <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-600 underline">ESMA interim MiCA register</a>, presented in a clearer, searchable format. See the <a href="about.html" class="text-blue-600 underline">methodology</a> for details.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">How often is it updated?</h3>
+    <p class="mt-1 leading-relaxed">Weekly, based on the latest processed ESMA register data. The snapshot date is shown above the table.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">Can I use this instead of the official ESMA register?</h3>
+    <p class="mt-1 leading-relaxed">No. The tracker is a first-look tool. Always verify a provider's formal authorisation status against ESMA or the relevant national competent authority before relying on it.</p>
+    </section>
+    </main>
+
+    <!-- ==== DEA FOOTER START ==== -->
+    <footer class="bg-gray-900 text-gray-200 mt-12">
+      <div class="max-w-7xl mx-auto px-4 py-10 space-y-10">
+        <div class="text-center">
+          <p class="text-gray-300">Digital Euro Association (DEA) MiCAR Tracker</p>
+          <p class="text-gray-400 text-sm mt-2">Source: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-300 underline hover:text-blue-200">ESMA interim MiCA register</a></p>
+        </div>
+        <div class="flex flex-col md:flex-row md:justify-between gap-8">
+          <nav aria-label="Registers">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Registers</p>
+            <ul class="space-y-2 text-sm">
+              <li><a href="casp-tracker.html" class="hover:text-white font-semibold">CASP Tracker</a></li>
+              <li><a href="emt-tracker.html" class="hover:text-white font-semibold">EMT Tracker</a></li>
+              <li><a href="non-compliant-casps.html" class="hover:text-white font-semibold">Non-Compliant CASPs</a></li>
+              <li><a href="index.html" class="hover:text-white font-semibold">Full dashboard</a></li>
+            </ul>
+          </nav>
+          <nav aria-label="Legal">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Digital Euro Association</p>
+            <ul class="space-y-2 text-sm">
+              <li><a href="https://home.digital-euro-association.de/legal-notice?hsLang=en"  target="_blank" rel="noopener" class="hover:text-white font-semibold">Legal Notice</a></li>
+              <li><a href="https://home.digital-euro-association.de/privacy-policy-0?hsLang=en" target="_blank" rel="noopener" class="hover:text-white font-semibold">Privacy</a></li>
+              <li><a href="https://home.digital-euro-association.de/impressum?hsLang=en"      target="_blank" rel="noopener" class="hover:text-white font-semibold">Impressum</a></li>
+            </ul>
+          </nav>
+          <div class="flex items-start gap-6 text-xl">
+            <a href="https://x.com/DigiEuro" target="_blank" rel="noopener" aria-label="Twitter" class="hover:text-white"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+            <a href="mailto:info@digital-euro-association.de" aria-label="Email" class="hover:text-white"><i class="fas fa-envelope" aria-hidden="true"></i></a>
+            <a href="https://www.linkedin.com/company/digital-euro-association/" target="_blank" rel="noopener" aria-label="LinkedIn" class="hover:text-white"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
+            <a href="https://github.com/DigiEuro/micardashboard" target="_blank" rel="noopener" aria-label="GitHub" class="hover:text-white"><i class="fab fa-github" aria-hidden="true"></i></a>
+          </div>
+        </div>
+        <div class="border-t border-gray-700 pt-6 flex flex-col md:flex-row md:justify-between md:items-center gap-4">
+          <p class="text-xs">&copy; <span id="year"></span> Digital Euro Association e.V.</p>
+          <a href="https://digital-euro-association.de" class="inline-block bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-5 py-2 rounded-lg shadow transition">Learn more about DEA</a>
+        </div>
+      </div>
+    </footer>
+    <!-- ==== DEA FOOTER END ==== -->
+
+    <script src="assets/js/register-view.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        var y = document.getElementById('year');
+        if (y) y.textContent = new Date().getFullYear();
+      });
+    </script>
+    <script type="module" defer>
+      import { polyfillCountryFlagEmojis } from './assets/vendor/flags/country-flag-emoji-polyfill.mjs';
+      polyfillCountryFlagEmojis('Twemoji Country Flags', 'assets/vendor/flags/TwemojiCountryFlags.woff2');
+    </script>
+</body>
+</html>

--- a/casp-tracker.html
+++ b/casp-tracker.html
@@ -129,7 +129,7 @@
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
     <section class="mb-8 text-white">
     <h2 class="text-2xl md:text-3xl font-bold mb-3">CASP Tracker</h2>
-    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    <p class="text-blue-100 leading-relaxed">
     Search <strong>Crypto-Asset Service Providers (CASPs)</strong> authorised under the EU's Markets in Crypto-Assets Regulation (MiCA / MiCAR), using public data from the ESMA interim MiCA register. View registered CASPs by country, competent authority, the services they provide and their website. Updated weekly by the Digital Euro Association; download the full list as CSV or JSON.
     </p>
     <p id="rvFreshness" class="text-sm text-blue-100 mt-3"></p>

--- a/emt-tracker.html
+++ b/emt-tracker.html
@@ -75,10 +75,56 @@
         <a href="non-compliant-casps.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant</a>
         <a href="about.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-circle-info mr-2" aria-hidden="true"></i>About</a>
       </nav>
+      <div class="md:hidden flex items-center hamburger-only">
+        <button id="mobile-menu-button"
+                type="button"
+                class="hamburger-button text-white hover:text-sky-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white"
+                aria-controls="mobile-menu"
+                aria-expanded="false"
+                aria-label="Open main menu">
+          <svg id="hamburger-icon" class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <svg id="close-icon" class="h-6 w-6 hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
     </div>
     </div>
     </div>
     </header>
+
+    <div id="mobile-menu-overlay" class="mobile-menu-overlay fixed inset-0 hidden" aria-hidden="true"></div>
+
+    <div id="mobile-menu" class="mobile-menu-container hidden">
+      <div class="mobile-menu-panel p-4">
+        <nav class="flex flex-col mobile-menu-list" aria-label="Mobile navigation">
+          <a href="index.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-chart-pie"></i></span>
+            <span class="mobile-menu-text">Overview</span>
+          </a>
+          <a href="emt-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-table"></i></span>
+            <span class="mobile-menu-text">EMTs</span>
+          </a>
+          <a href="casp-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-building-columns"></i></span>
+            <span class="mobile-menu-text">CASPs</span>
+          </a>
+          <a href="non-compliant-casps.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-exclamation-triangle"></i></span>
+            <span class="mobile-menu-text">Non-Compliant</span>
+          </a>
+          <a href="about.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-circle-info"></i></span>
+            <span class="mobile-menu-text">About</span>
+          </a>
+        </nav>
+      </div>
+    </div>
 
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
     <section class="mb-8 text-white">
@@ -146,6 +192,15 @@
     </footer>
     <!-- ==== DEA FOOTER END ==== -->
 
+    <script>
+      window.addEventListener('scroll', function () {
+        var header = document.querySelector('.header-sticky');
+        if (!header) return;
+        if (window.scrollY > 20) header.classList.add('shrink');
+        else header.classList.remove('shrink');
+      });
+    </script>
+    <script src="assets/js/mobile-menu.js" defer></script>
     <script src="assets/js/register-view.js" defer></script>
     <script>
       document.addEventListener('DOMContentLoaded', function () {

--- a/emt-tracker.html
+++ b/emt-tracker.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev; object-src 'none'; base-uri 'self'; form-action 'self'">
+    <title>EMT Tracker — MiCA E-Money Token Issuers (ESMA Register)</title>
+    <meta name="description" content="Track MiCA-authorised e-money token (EMT) issuers from the ESMA register. View EMT issuers by country, competent authority, token and backing currency. Updated weekly by the Digital Euro Association. Free CSV/JSON download.">
+    <link rel="canonical" href="https://micatracker.digital-euro-association.de/emt-tracker.html">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://micatracker.digital-euro-association.de/emt-tracker.html">
+    <meta property="og:title" content="EMT Tracker — MiCA E-Money Token Issuers (ESMA Register)">
+    <meta property="og:description" content="Track MiCA-authorised e-money token issuers from the ESMA register, by country, competent authority, token and currency. Updated weekly.">
+    <meta property="og:image" content="https://micatracker.digital-euro-association.de/cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="EMT Tracker — MiCA E-Money Token Issuers (ESMA Register)">
+    <meta name="twitter:description" content="Track MiCA-authorised e-money token issuers from the ESMA register, by country, competent authority, token and currency. Updated weekly.">
+    <meta name="twitter:image" content="https://micatracker.digital-euro-association.de/cover.png">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="alternate" type="application/rss+xml" title="MiCAR Tracker register updates" href="feed.xml">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      "name": "MiCA-authorised E-Money Token (EMT) issuers",
+      "description": "E-money token (EMT) issuers authorised under the EU Markets in Crypto-Assets Regulation (MiCAR), derived from the ESMA interim MiCA register. Includes country, competent authority, tokens and backing currency.",
+      "url": "https://micatracker.digital-euro-association.de/casp-tracker.html",
+      "keywords": ["EMT", "e-money token", "MiCA", "MiCAR", "stablecoin", "ESMA"],
+      "creator": { "@type": "Organization", "name": "Digital Euro Association", "url": "https://digital-euro-association.de" },
+      "isBasedOn": "https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister",
+      "distribution": [
+        { "@type": "DataDownload", "encodingFormat": "application/json", "contentUrl": "https://micatracker.digital-euro-association.de/data/emts.json" }
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        { "@type": "Question", "name": "What is an EMT under MiCAR?", "acceptedAnswer": { "@type": "Answer", "text": "An EMT (e-money token) is a crypto-asset that references a single official currency and is issued under the EU Markets in Crypto-Assets Regulation (MiCA/MiCAR)." } },
+        { "@type": "Question", "name": "Where does the EMT Tracker data come from?", "acceptedAnswer": { "@type": "Answer", "text": "The EMT Tracker uses public ESMA interim MiCA register data and presents it in a clearer, searchable format." } },
+        { "@type": "Question", "name": "How often is the EMT Tracker updated?", "acceptedAnswer": { "@type": "Answer", "text": "It is updated weekly based on the latest processed ESMA register data." } },
+        { "@type": "Question", "name": "Can I use this instead of the official ESMA register?", "acceptedAnswer": { "@type": "Answer", "text": "No. The tracker is a first-look tool. Verify formal authorisation status against ESMA or the relevant national competent authority." } }
+      ]
+    }
+    </script>
+    <link rel="stylesheet" href="styles/tailwind.css">
+    <link rel="stylesheet" href="styles/site.css">
+    <link rel="stylesheet" href="assets/vendor/inter/inter.css">
+    <link rel="stylesheet" href="assets/vendor/fontawesome/css/all.min.css">
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="dbd82f5d-689a-452f-9fff-fba85b9de507"></script>
+</head>
+<body class="main-bg">
+    <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-900 focus:font-semibold focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-lg">Skip to main content</a>
+    <header class="header-sticky shadow-2xl">
+    <div class="max-w-7xl mx-auto px-6 py-6">
+    <div class="flex items-center justify-between flex-wrap header-content">
+    <div class="flex items-center space-x-6 mb-4 md:mb-0">
+        <a href="index.html" class="inline-flex items-center" aria-label="Return to the dashboard">
+        <img src="DEA%20logo%20white.png" alt="DEA Logo" class="logo-container">
+        </a>
+        <div class="flex items-center">
+            <h1 class="text-[1.8rem] md:text-[2.2rem] font-bold text-white mb-0 leading-tight">
+                <span class="text-sky-100">MiCAR</span>
+                <span class="text-sky-50">Tracker</span>
+            </h1>
+        </div>
+    </div>
+    <div class="flex items-center gap-3 header-actions">
+      <nav class="hidden md:flex items-center nav-buttons" aria-label="Main navigation">
+        <a href="index.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-chart-pie mr-2" aria-hidden="true"></i>Overview</a>
+        <a href="emt-tracker.html" class="tab-button tab-active px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-table mr-2" aria-hidden="true"></i>EMTs</a>
+        <a href="casp-tracker.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-building-columns mr-2" aria-hidden="true"></i>CASPs</a>
+        <a href="non-compliant-casps.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant</a>
+        <a href="about.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-circle-info mr-2" aria-hidden="true"></i>About</a>
+      </nav>
+    </div>
+    </div>
+    </div>
+    </header>
+
+    <main id="main" class="max-w-7xl mx-auto px-6 py-8">
+    <section class="mb-8 text-white">
+    <h2 class="text-2xl md:text-3xl font-bold mb-3">EMT Tracker</h2>
+    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    Track <strong>e-money token (EMT) issuers</strong> authorised under the EU's Markets in Crypto-Assets Regulation (MiCA / MiCAR), using public data from the ESMA interim MiCA register. View EMT issuers by country, competent authority, the tokens they issue and the backing currency. Updated weekly by the Digital Euro Association; download the full list as CSV or JSON.
+    </p>
+    <p id="rvFreshness" class="text-sm text-blue-100 mt-3"></p>
+    </section>
+
+    <div id="registerRoot" data-register="emt">
+    <div class="rounded-2xl bg-white bg-opacity-90 p-4 text-gray-700 text-sm">Loading EMT register&hellip;</div>
+    </div>
+
+    <section class="mt-10 bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 md:p-8 text-gray-700">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4">EMT Tracker FAQ</h2>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">What is an EMT under MiCAR?</h3>
+    <p class="mt-1 leading-relaxed">An e-money token (EMT) is a type of crypto-asset that references the value of a single official currency (for example a euro or US-dollar stablecoin) and is issued under the EU Markets in Crypto-Assets Regulation.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">Where does the CASP Tracker data come from?</h3>
+    <p class="mt-1 leading-relaxed">It uses public data from the <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-600 underline">ESMA interim MiCA register</a>, presented in a clearer, searchable format. See the <a href="about.html" class="text-blue-600 underline">methodology</a> for details.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">How often is it updated?</h3>
+    <p class="mt-1 leading-relaxed">Weekly, based on the latest processed ESMA register data. The snapshot date is shown above the table.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">Can I use this instead of the official ESMA register?</h3>
+    <p class="mt-1 leading-relaxed">No. The tracker is a first-look tool. Always verify an issuer's formal authorisation status against ESMA or the relevant national competent authority before relying on it.</p>
+    </section>
+    </main>
+
+    <!-- ==== DEA FOOTER START ==== -->
+    <footer class="bg-gray-900 text-gray-200 mt-12">
+      <div class="max-w-7xl mx-auto px-4 py-10 space-y-10">
+        <div class="text-center">
+          <p class="text-gray-300">Digital Euro Association (DEA) MiCAR Tracker</p>
+          <p class="text-gray-400 text-sm mt-2">Source: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-300 underline hover:text-blue-200">ESMA interim MiCA register</a></p>
+        </div>
+        <div class="flex flex-col md:flex-row md:justify-between gap-8">
+          <nav aria-label="Registers">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Registers</p>
+            <ul class="space-y-2 text-sm">
+              <li><a href="casp-tracker.html" class="hover:text-white font-semibold">CASP Tracker</a></li>
+              <li><a href="emt-tracker.html" class="hover:text-white font-semibold">EMT Tracker</a></li>
+              <li><a href="non-compliant-casps.html" class="hover:text-white font-semibold">Non-Compliant CASPs</a></li>
+              <li><a href="index.html" class="hover:text-white font-semibold">Full dashboard</a></li>
+            </ul>
+          </nav>
+          <nav aria-label="Legal">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Digital Euro Association</p>
+            <ul class="space-y-2 text-sm">
+              <li><a href="https://home.digital-euro-association.de/legal-notice?hsLang=en"  target="_blank" rel="noopener" class="hover:text-white font-semibold">Legal Notice</a></li>
+              <li><a href="https://home.digital-euro-association.de/privacy-policy-0?hsLang=en" target="_blank" rel="noopener" class="hover:text-white font-semibold">Privacy</a></li>
+              <li><a href="https://home.digital-euro-association.de/impressum?hsLang=en"      target="_blank" rel="noopener" class="hover:text-white font-semibold">Impressum</a></li>
+            </ul>
+          </nav>
+          <div class="flex items-start gap-6 text-xl">
+            <a href="https://x.com/DigiEuro" target="_blank" rel="noopener" aria-label="Twitter" class="hover:text-white"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+            <a href="mailto:info@digital-euro-association.de" aria-label="Email" class="hover:text-white"><i class="fas fa-envelope" aria-hidden="true"></i></a>
+            <a href="https://www.linkedin.com/company/digital-euro-association/" target="_blank" rel="noopener" aria-label="LinkedIn" class="hover:text-white"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
+            <a href="https://github.com/DigiEuro/micardashboard" target="_blank" rel="noopener" aria-label="GitHub" class="hover:text-white"><i class="fab fa-github" aria-hidden="true"></i></a>
+          </div>
+        </div>
+        <div class="border-t border-gray-700 pt-6 flex flex-col md:flex-row md:justify-between md:items-center gap-4">
+          <p class="text-xs">&copy; <span id="year"></span> Digital Euro Association e.V.</p>
+          <a href="https://digital-euro-association.de" class="inline-block bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-5 py-2 rounded-lg shadow transition">Learn more about DEA</a>
+        </div>
+      </div>
+    </footer>
+    <!-- ==== DEA FOOTER END ==== -->
+
+    <script src="assets/js/register-view.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        var y = document.getElementById('year');
+        if (y) y.textContent = new Date().getFullYear();
+      });
+    </script>
+    <script type="module" defer>
+      import { polyfillCountryFlagEmojis } from './assets/vendor/flags/country-flag-emoji-polyfill.mjs';
+      polyfillCountryFlagEmojis('Twemoji Country Flags', 'assets/vendor/flags/TwemojiCountryFlags.woff2');
+    </script>
+</body>
+</html>

--- a/emt-tracker.html
+++ b/emt-tracker.html
@@ -129,7 +129,7 @@
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
     <section class="mb-8 text-white">
     <h2 class="text-2xl md:text-3xl font-bold mb-3">EMT Tracker</h2>
-    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    <p class="text-blue-100 leading-relaxed">
     Track <strong>e-money token (EMT) issuers</strong> authorised under the EU's Markets in Crypto-Assets Regulation (MiCA / MiCAR), using public data from the ESMA interim MiCA register. View EMT issuers by country, competent authority, the tokens they issue and the backing currency. Updated weekly by the Digital Euro Association; download the full list as CSV or JSON.
     </p>
     <p id="rvFreshness" class="text-sm text-blue-100 mt-3"></p>

--- a/index.html
+++ b/index.html
@@ -65,51 +65,18 @@
     <link rel="stylesheet" href="assets/vendor/fontawesome/css/all.min.css">
     <script defer src="https://cloud.umami.is/script.js" data-website-id="dbd82f5d-689a-452f-9fff-fba85b9de507"></script>
     <style>
-    /* Shared header / nav / body chrome now lives in styles/site.css */
-    .card-hover {
-    transition: all 0.3s ease;
-    }
-
-    .card-hover:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-    }
-
+    /* Shared header / nav / body chrome, KPI summary cards, card-hover /
+       fade-in animations, and register table styles all live in
+       styles/site.css - shared with the casp-tracker / emt-tracker /
+       non-compliant-casps intent pages. */
     .progress-bar {
     transition: width 0.8s ease-in-out;
     }
-
-    .fade-in {
-    animation: fadeIn 0.6s ease-in;
-    }
-
-    @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
-    }
-
-    .kpi-card {
-    background: linear-gradient(135deg, var(--start-color), var(--end-color));
-    }
-
-    /* Complementary colors to the teal-blue gradient */
-    .kpi-teal { --start-color: #14b8a6; --end-color: #0f766e; }
-    .kpi-blue { --start-color: #0ea5e9; --end-color: #0369a1; }
-    .kpi-orange { --start-color: #f97316; --end-color: #ea580c; }
-    .kpi-coral { --start-color: #f43f5e; --end-color: #e11d48; }
-    .kpi-purple { --start-color: #8b5cf6; --end-color: #7c3aed; }
-    .kpi-red { --start-color: #dc2626; --end-color: #b91c1c; }
-    .kpi-green { --start-color: #10b981; --end-color: #059669; }
-    .kpi-yellow { --start-color: #f59e0b; --end-color: #d97706; }
 
     .content-bg {
     background: rgba(255, 255, 255, 0.05);
     backdrop-filter: blur(10px);
     }
-
-    /* Register table styles (data-table, sticky headers, sort buttons,
-       search-input, badges) live in styles/site.css - shared with the
-       casp-tracker / emt-tracker / non-compliant-casps pages */
     </style>
 </head>
 <body class="main-bg">
@@ -209,17 +176,12 @@
     <a href="non-compliant-casps.html" class="underline hover:text-white">entities flagged as non-compliant</a>
     by country, competent authority, services and token. Updated weekly; download any register as CSV or JSON.
     </p>
-    <ul class="mt-3 flex flex-wrap gap-3 text-sm font-semibold">
-    <li><a href="casp-tracker.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">CASP Tracker</a></li>
-    <li><a href="emt-tracker.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">EMT Tracker</a></li>
-    <li><a href="non-compliant-casps.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">Non-Compliant CASPs</a></li>
-    </ul>
+    <p id="dataFreshness" class="text-sm text-blue-100 mt-3"></p>
     </section>
 
-    <div class="mb-6 text-white space-y-2">
+    <div class="mb-4 text-white">
     <h2 class="text-2xl font-semibold">EMT Issuer Insights</h2>
     <p class="text-blue-100">Key indicators and distributions for licensed Electronic Money Token issuers.</p>
-    <p id="dataFreshness" class="text-sm text-blue-100"></p>
     </div>
 
     <div id="dataLoadingNotice" class="mb-6 rounded-2xl bg-white bg-opacity-90 p-4 text-gray-700 text-sm">
@@ -258,8 +220,8 @@
 
     <div class="h-px bg-white/30 my-10"></div>
 
-    <div class="mb-6 text-white">
-    <h2 id="caspsSectionTitle" class="text-2xl font-semibold">CASPs Insights</h2>
+    <div class="mb-4 text-white">
+    <h2 class="text-2xl font-semibold">CASPs Insights</h2>
     <p class="text-blue-100">Overview of registered Crypto-Asset Service Providers by country and authority.</p>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -119,9 +119,9 @@
     <div class="max-w-7xl mx-auto px-6 py-6">
     <div class="flex items-center justify-between flex-wrap header-content">
     <div class="flex items-center space-x-6 mb-4 md:mb-0">
-        <img src="DEA%20logo%20white.png"
-             alt="DEA Logo" id="homeLogo" class="logo-container" role="button" tabindex="0"
-             aria-label="Return to the default dashboard view">
+        <a href="index.html" class="inline-flex items-center" aria-label="Return to the dashboard">
+        <img src="DEA%20logo%20white.png" alt="DEA Logo" class="logo-container">
+        </a>
         <div class="flex items-center">
             <h1 class="text-[1.8rem] md:text-[2.2rem] font-bold text-white mb-0 leading-tight">
                 <span class="text-sky-100">MiCAR</span>
@@ -131,20 +131,18 @@
     </div>
     <div class="flex items-center gap-3 header-actions">
       <nav class="hidden md:flex items-center nav-buttons" aria-label="Main navigation">
-        <div id="dashboardTablist" role="tablist" aria-label="Dashboard sections" class="contents">
-        <button id="overviewBtn" role="tab" aria-selected="true" aria-controls="overviewSection" class="tab-button tab-active px-5 py-3 rounded-xl font-semibold">
-        <i class="fas fa-chart-pie mr-2" aria-hidden="true"></i>Overview
-        </button>
-        <button id="detailsBtn" role="tab" aria-selected="false" aria-controls="detailsSection" tabindex="-1" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold">
-        <i class="fas fa-table mr-2" aria-hidden="true"></i>EMTs
-        </button>
-        <button id="caspsBtn" role="tab" aria-selected="false" aria-controls="caspsSection" tabindex="-1" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold">
-        <i class="fas fa-building-columns mr-2" aria-hidden="true"></i>CASPs
-        </button>
-        <button id="nonCompliantBtn" role="tab" aria-selected="false" aria-controls="nonCompliantSection" tabindex="-1" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold">
-        <i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant
-        </button>
-        </div>
+        <a href="index.html" aria-current="page" class="tab-button tab-active px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center">
+          <i class="fas fa-chart-pie mr-2" aria-hidden="true"></i>Overview
+        </a>
+        <a href="emt-tracker.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center">
+          <i class="fas fa-table mr-2" aria-hidden="true"></i>EMTs
+        </a>
+        <a href="casp-tracker.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center">
+          <i class="fas fa-building-columns mr-2" aria-hidden="true"></i>CASPs
+        </a>
+        <a href="non-compliant-casps.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center">
+          <i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant
+        </a>
         <a href="about.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center">
           <i class="fas fa-circle-info mr-2" aria-hidden="true"></i>About
         </a>
@@ -176,22 +174,22 @@
     <div id="mobile-menu" class="mobile-menu-container hidden">
       <div class="mobile-menu-panel p-4">
         <nav class="flex flex-col mobile-menu-list" aria-label="Mobile navigation">
-          <button type="button" data-tab-target="overview" class="mobile-menu-link mobile-menu-item text-base font-medium text-left">
+          <a href="index.html" aria-current="page" class="mobile-menu-link mobile-menu-item text-base font-medium">
             <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-chart-pie"></i></span>
             <span class="mobile-menu-text">Overview</span>
-          </button>
-          <button type="button" data-tab-target="details" class="mobile-menu-link mobile-menu-item text-base font-medium text-left">
+          </a>
+          <a href="emt-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
             <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-table"></i></span>
             <span class="mobile-menu-text">EMTs</span>
-          </button>
-          <button type="button" data-tab-target="casps" class="mobile-menu-link mobile-menu-item text-base font-medium text-left">
+          </a>
+          <a href="casp-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
             <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-building-columns"></i></span>
             <span class="mobile-menu-text">CASPs</span>
-          </button>
-          <button type="button" data-tab-target="nonCompliant" class="mobile-menu-link mobile-menu-item text-base font-medium text-left">
+          </a>
+          <a href="non-compliant-casps.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
             <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-exclamation-triangle"></i></span>
             <span class="mobile-menu-text">Non-Compliant</span>
-          </button>
+          </a>
           <a href="about.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
             <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-circle-info"></i></span>
             <span class="mobile-menu-text">About</span>
@@ -218,13 +216,10 @@
     </ul>
     </section>
 
-    <div id="sectionIntro" class="mb-6 text-white space-y-4 md:space-y-6">
-    <h2 id="sectionTitle" class="text-2xl font-semibold">EMT Issuer Insights</h2>
-    <p id="sectionDescription" class="text-blue-100">Key indicators and distributions for licensed Electronic Money Token issuers.</p>
+    <div class="mb-6 text-white space-y-2">
+    <h2 class="text-2xl font-semibold">EMT Issuer Insights</h2>
+    <p class="text-blue-100">Key indicators and distributions for licensed Electronic Money Token issuers.</p>
     <p id="dataFreshness" class="text-sm text-blue-100"></p>
-    <div id="caspsIntroKpiContainer" class="hidden grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 fade-in">
-    <!-- CASPs KPI cards duplicated for section intro -->
-    </div>
     </div>
 
     <div id="dataLoadingNotice" class="mb-6 rounded-2xl bg-white bg-opacity-90 p-4 text-gray-700 text-sm">
@@ -239,8 +234,7 @@
     <!-- Will be populated dynamically by JavaScript -->
     </div>
 
-    <!-- Overview Section -->
-    <div id="overviewSection" role="tabpanel" aria-labelledby="overviewBtn" class="fade-in">
+    <div class="fade-in">
     <!-- Charts Row -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
     <div class="bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 card-hover">
@@ -304,191 +298,6 @@
     </div>
     <div id="changelogContainer" class="space-y-4 text-sm text-gray-700">
     <p class="text-gray-500">Loading change history&hellip;</p>
-    </div>
-    </div>
-    </div>
-
-    <!-- Details Section -->
-    <div id="detailsSection" role="tabpanel" aria-labelledby="detailsBtn" class="hidden fade-in">
-    <div class="bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 card-hover">
-    <div class="flex flex-col md:flex-row md:items-center justify-between mb-6">
-    <h3 class="text-xl font-bold text-gray-800 mb-4 md:mb-0">
-    <i class="fas fa-list-alt text-teal-600 mr-2" aria-hidden="true"></i>Detailed Issuer Information
-    </h3>
-    <div class="flex items-center space-x-4">
-    <div class="relative">
-    <input type="text" id="searchInput" placeholder="Search issuers, countries, tokens..."
-    aria-label="Search EMT issuers by name, country, authority, or token"
-    class="search-input pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent w-64">
-    <i class="fas fa-search absolute left-3 top-3 text-gray-400" aria-hidden="true"></i>
-    </div>
-    <button id="clearSearch" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors">
-    <i class="fas fa-times mr-1" aria-hidden="true"></i>Clear
-    </button>
-    <button id="exportEmtCsv" class="px-3 py-2 text-sm bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors whitespace-nowrap">
-    <i class="fas fa-download mr-1" aria-hidden="true"></i>CSV
-    </button>
-    <a href="data/emts.json" download="micar-emts.json" class="px-3 py-2 text-sm bg-teal-100 text-teal-800 rounded-lg hover:bg-teal-200 transition-colors whitespace-nowrap font-semibold">JSON</a>
-    </div>
-    </div>
-    <div class="data-table-container">
-    <table class="data-table w-full">
-    <caption class="sr-only">Electronic Money Token issuers authorised under MiCAR</caption>
-    <colgroup>
-    <col style="width: 26%;">
-    <col style="width: 20%;">
-    <col style="width: 18%;">
-    <col style="width: 18%;">
-    <col style="width: 8%;">
-    <col style="width: 10%;">
-    </colgroup>
-    <thead class="sticky-table-header teal">
-    <tr class="bg-gradient-to-r from-teal-50 to-blue-50">
-    <th scope="col" aria-sort="none" data-sort-key="issuer" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Issuer<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" aria-sort="none" data-sort-key="state" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Country<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" aria-sort="none" data-sort-key="authority" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Authority<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" class="text-left p-4 font-semibold text-gray-700">Tokens</th>
-    <th scope="col" aria-sort="none" data-sort-key="count" class="text-center p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Count<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" class="text-center p-4 font-semibold text-gray-700">Currencies</th>
-    </tr>
-    </thead>
-    <tbody id="detailsTable">
-    <!-- Will be populated by JavaScript -->
-    </tbody>
-    </table>
-    </div>
-    <div id="noResults" class="hidden text-center py-8 text-gray-500">
-    <i class="fas fa-search text-4xl mb-4" aria-hidden="true"></i>
-    <p class="text-lg">No results found for your search.</p>
-    </div>
-    </div>
-    </div>
-
-    <!-- CASPs Section -->
-    <div id="caspsSection" role="tabpanel" aria-labelledby="caspsBtn" class="hidden fade-in">
-    <div class="bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 card-hover">
-    <div class="flex flex-col md:flex-row md:items-center justify-between mb-6">
-    <h3 class="text-xl font-bold text-gray-800 mb-4 md:mb-0">
-    <i class="fas fa-building text-teal-600 mr-2" aria-hidden="true"></i>Crypto-Asset Service Providers (CASPs)
-    </h3>
-    <div class="flex flex-wrap items-center gap-3">
-    <select id="caspsCountryFilter" aria-label="Filter CASPs by country"
-    class="search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent">
-    <option value="">All countries</option>
-    </select>
-    <select id="caspsServiceFilter" aria-label="Filter CASPs by service"
-    class="search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent">
-    <option value="">All services</option>
-    </select>
-    <div class="relative">
-    <input type="text" id="caspsSearchInput" placeholder="Search CASPs, countries, services..."
-    aria-label="Search CASPs by name, country, authority, service, or website"
-    class="search-input pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent w-64">
-    <i class="fas fa-search absolute left-3 top-3 text-gray-400" aria-hidden="true"></i>
-    </div>
-    <button id="clearCaspsSearch" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors">
-    <i class="fas fa-times mr-1" aria-hidden="true"></i>Clear
-    </button>
-    <div class="flex items-center gap-3">
-    <span class="text-sm text-gray-500">Download:</span>
-    <button id="exportCaspsCsv" class="px-3 py-2 text-sm bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors whitespace-nowrap">
-    <i class="fas fa-download mr-1" aria-hidden="true"></i>CSV
-    </button>
-    <a href="data/casps.json" download="micar-casps.json" class="px-3 py-2 text-sm bg-teal-100 text-teal-800 rounded-lg hover:bg-teal-200 transition-colors whitespace-nowrap font-semibold">JSON</a>
-    </div>
-    </div>
-    </div>
-
-    <div class="data-table-container">
-    <table class="data-table casps-data-table w-full">
-    <caption class="sr-only">Crypto-Asset Service Providers registered under MiCAR</caption>
-    <colgroup>
-    <col style="width: 4%;">
-    <col style="width: 24%;">
-    <col style="width: 16%;">
-    <col style="width: 10%;">
-    <col style="width: 28%;">
-    <col style="width: 18%;">
-    </colgroup>
-    <thead class="sticky-table-header teal">
-    <tr class="bg-gradient-to-r from-teal-50 to-blue-50">
-    <th scope="col" class="text-left p-4 font-semibold text-gray-700">#</th>
-    <th scope="col" aria-sort="none" data-sort-key="name" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">CASP<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" aria-sort="none" data-sort-key="memberState" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Country<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" aria-sort="none" data-sort-key="authority" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Competent Authority<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" class="text-left p-4 font-semibold text-gray-700 services-cell">Services</th>
-    <th scope="col" class="text-left p-4 font-semibold text-gray-700">Websites</th>
-    </tr>
-    </thead>
-    <tbody id="caspsTable">
-    <!-- Will be populated by JavaScript -->
-    </tbody>
-    </table>
-    </div>
-    <div id="noCaspsResults" class="hidden text-center py-8 text-gray-500">
-    <i class="fas fa-search text-4xl mb-4" aria-hidden="true"></i>
-    <p class="text-lg">No CASPs match your search.</p>
-    </div>
-    </div>
-    </div>
-
-    <!-- Non-Compliant Section -->
-    <div id="nonCompliantSection" role="tabpanel" aria-labelledby="nonCompliantBtn" class="hidden fade-in">
-    <div class="bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 card-hover">
-    <div class="flex flex-col md:flex-row md:items-center justify-between mb-6">
-    <h3 class="text-xl font-bold text-gray-800 mb-4 md:mb-0">
-    <i class="fas fa-exclamation-triangle text-red-600 mr-2" aria-hidden="true"></i>Non-Compliant Entities
-    </h3>
-    <div class="flex flex-col md:flex-row md:items-center gap-3">
-    <div class="relative">
-    <input type="text" id="nonCompliantSearchInput" placeholder="Search entities, authorities, websites..."
-    aria-label="Search non-compliant entities by name, country, authority, or website"
-    class="search-input pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-red-500 focus:border-transparent w-64">
-    <i class="fas fa-search absolute left-3 top-3 text-gray-400" aria-hidden="true"></i>
-    </div>
-    <button id="toggleNewNonCompliant" class="px-3 py-2 text-sm bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors font-semibold whitespace-nowrap" aria-pressed="false">
-    <i class="fas fa-star mr-1" aria-hidden="true"></i>New only
-    </button>
-    <button id="clearNonCompliantSearch" class="px-3 py-2 text-sm bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors whitespace-nowrap">
-    <i class="fas fa-times mr-1" aria-hidden="true"></i>Clear
-    </button>
-    <button id="exportNonCompliantCsv" class="px-3 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors whitespace-nowrap">
-    <i class="fas fa-download mr-1" aria-hidden="true"></i>CSV
-    </button>
-    <a href="data/non-compliant.json" download="micar-non-compliant.json" class="px-3 py-2 text-sm bg-red-100 text-red-800 rounded-lg hover:bg-red-200 transition-colors whitespace-nowrap font-semibold">JSON</a>
-    </div>
-    </div>
-    <p id="nonCompliantNewSummary" class="text-sm text-gray-600 mb-4"></p>
-
-    <div class="data-table-container">
-    <table class="data-table w-full">
-    <caption class="sr-only">Entities flagged as non-compliant by European regulators</caption>
-    <colgroup>
-    <col style="width: 5%;">
-    <col style="width: 25%;">
-    <col style="width: 14%;">
-    <col style="width: 20%;">
-    <col style="width: 26%;">
-    <col style="width: 10%;">
-    </colgroup>
-    <thead class="sticky-table-header red">
-    <tr class="bg-gradient-to-r from-red-50 to-orange-50">
-    <th scope="col" class="text-left p-4 font-semibold text-gray-700">#</th>
-    <th scope="col" aria-sort="none" data-sort-key="entity" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Entity Name<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" aria-sort="none" data-sort-key="country" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Country<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" aria-sort="none" data-sort-key="authority" class="text-left p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Regulatory Authority<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    <th scope="col" class="text-left p-4 font-semibold text-gray-700">Websites</th>
-    <th scope="col" aria-sort="none" data-sort-key="isNew" class="text-center p-4 font-semibold text-gray-700"><button type="button" class="sort-button">Status<span class="sort-indicator" aria-hidden="true"></span></button></th>
-    </tr>
-    </thead>
-    <tbody id="nonCompliantTable">
-    <!-- Will be populated by JavaScript -->
-    </tbody>
-    </table>
-    </div>
-    <div id="noNonCompliantResults" class="hidden text-center py-8 text-gray-500">
-    <i class="fas fa-search text-4xl mb-4" aria-hidden="true"></i>
-    <p class="text-lg">No results found for your search.</p>
     </div>
     </div>
     </div>
@@ -699,11 +508,6 @@
     let caspsData = [];
     let nonCompliantData = [];
 
-    let filteredData = [];
-    let filteredCaspsData = [];
-    let filteredNonCompliantData = [];
-    let showNewNonCompliantOnly = false;
-
     async function fetchJson(url) {
         const response = await fetch(url, { cache: 'no-cache' });
         if (!response.ok) {
@@ -726,9 +530,6 @@
         data = emts;
         caspsData = casps;
         nonCompliantData = nonCompliant;
-        filteredData = [...data];
-        filteredCaspsData = [...caspsData];
-        filteredNonCompliantData = [...nonCompliantData];
     }
 
     const changelogRegisterLabels = {
@@ -838,68 +639,6 @@
         }
     }
 
-    const sectionTitleEl = document.getElementById('sectionTitle');
-    const sectionDescriptionEl = document.getElementById('sectionDescription');
-    const kpiContainerEl = document.getElementById('kpiContainer');
-    const caspsIntroKpiContainerEl = document.getElementById('caspsIntroKpiContainer');
-
-    const sectionIntroConfig = {
-        overview: {
-            title: 'EMT Issuer Insights',
-            description: 'Key indicators and distributions for licensed Electronic Money Token issuers.',
-            showKpis: true
-        },
-        details: {
-            title: 'EMT Issuer Details',
-            description: 'Explore detailed records for each Electronic Money Token issuer authorised under MiCAR.',
-            showKpis: true
-        },
-        casps: {
-            title: 'CASPs Overview',
-            description: 'Discover authorised Crypto-Asset Service Providers and the services they offer across Europe.',
-            showKpis: false
-        },
-        nonCompliant: {
-            title: 'Non-Compliant Entities',
-            description: 'Monitor CASPs and related entities flagged by European regulators for non-compliant activity. Please refrain from visiting the listed websites, as many are suspected of hosting phishing or other malicious content.',
-            showKpis: false
-        }
-    };
-
-    function updateSectionIntro(tab) {
-        const config = sectionIntroConfig[tab] || sectionIntroConfig.overview;
-
-        if (sectionTitleEl) {
-            sectionTitleEl.textContent = config.title;
-        }
-
-        if (sectionDescriptionEl) {
-            if (config.description) {
-                sectionDescriptionEl.textContent = config.description;
-                sectionDescriptionEl.classList.remove('hidden');
-            } else {
-                sectionDescriptionEl.textContent = '';
-                sectionDescriptionEl.classList.add('hidden');
-            }
-        }
-
-        if (kpiContainerEl) {
-            if (config.showKpis) {
-                kpiContainerEl.classList.remove('hidden');
-            } else {
-                kpiContainerEl.classList.add('hidden');
-            }
-        }
-
-        if (caspsIntroKpiContainerEl) {
-            if (tab === 'casps') {
-                caspsIntroKpiContainerEl.classList.remove('hidden');
-            } else {
-                caspsIntroKpiContainerEl.classList.add('hidden');
-            }
-        }
-    }
-
     // Dynamic calculation functions
     function getCurrencyFields(items) {
         const standardFields = ['id', 'issuer', 'state', 'authority', 'tokens', 'count'];
@@ -994,7 +733,7 @@
         });
         const uniqueCountries = new Set(normalizedCountries.map(country => country.toLowerCase()));
         const totalCountries = normalizedCountries.length > 0 ? uniqueCountries.size : 0;
-        const nonCompliantCaspsCount = filteredNonCompliantData.length;
+        const nonCompliantCaspsCount = nonCompliantData.length;
 
         return `
             <div class="kpi-card kpi-teal p-6 rounded-2xl shadow-lg text-white card-hover">
@@ -1030,18 +769,10 @@
         `;
     }
 
-    function updateCaspsKpis(dataToShow = filteredCaspsData) {
+    function updateCaspsKpis() {
         const container = document.getElementById('caspsKpiContainer');
-        const introContainer = document.getElementById('caspsIntroKpiContainer');
-
-        const cardsHtml = buildCaspsKpiCards(dataToShow);
-
         if (container) {
-            container.innerHTML = cardsHtml;
-        }
-
-        if (introContainer) {
-            introContainer.innerHTML = cardsHtml;
+            container.innerHTML = buildCaspsKpiCards(caspsData);
         }
     }
 
@@ -1067,83 +798,6 @@
         caspsAuthorityData = countBy(caspsData, item => item.authority || 'Unknown');
     }
 
-    // Column sorting (per-table state; null key = original sheet order)
-    const sortStates = {
-        emt: { key: null, dir: 1 },
-        casps: { key: null, dir: 1 },
-        nonCompliant: { key: null, dir: 1 }
-    };
-
-    function sortRows(rows, state) {
-        if (!state.key) {
-            return rows;
-        }
-        return [...rows].sort((a, b) => {
-            const va = a[state.key];
-            const vb = b[state.key];
-            if (typeof va === 'number' || typeof vb === 'number' || typeof va === 'boolean' || typeof vb === 'boolean') {
-                return (Number(va || 0) - Number(vb || 0)) * state.dir;
-            }
-            return String(va || '').localeCompare(String(vb || ''), 'en', { sensitivity: 'base' }) * state.dir;
-        });
-    }
-
-    function initSortableHeaders(tbodyId, state, rerender) {
-        const tbody = document.getElementById(tbodyId);
-        if (!tbody) {
-            return;
-        }
-        const headers = tbody.closest('table').querySelectorAll('th[data-sort-key]');
-        headers.forEach(th => {
-            const button = th.querySelector('.sort-button');
-            if (!button) {
-                return;
-            }
-            button.addEventListener('click', () => {
-                const key = th.dataset.sortKey;
-                if (state.key === key) {
-                    state.dir = -state.dir;
-                } else {
-                    state.key = key;
-                    state.dir = 1;
-                }
-                headers.forEach(header => {
-                    const active = header === th;
-                    header.setAttribute('aria-sort', active ? (state.dir === 1 ? 'ascending' : 'descending') : 'none');
-                    const indicator = header.querySelector('.sort-indicator');
-                    if (indicator) {
-                        indicator.textContent = active ? (state.dir === 1 ? '▲' : '▼') : '';
-                    }
-                });
-                rerender();
-            });
-        });
-    }
-
-    // CSV export of the currently visible (filtered + sorted) view
-    function csvEscape(value) {
-        const str = String(value ?? '');
-        return /[",\n]/.test(str) ? '"' + str.replace(/"/g, '""') + '"' : str;
-    }
-
-    function downloadCsv(filename, columns, rows) {
-        if (rows.length === 0) {
-            return;
-        }
-        const header = columns.map(col => csvEscape(col.label)).join(',');
-        const lines = rows.map(row => columns.map(col => csvEscape(col.value(row))).join(','));
-        // BOM so Excel detects UTF-8
-        const blob = new Blob(['\uFEFF' + [header, ...lines].join('\r\n')], { type: 'text/csv;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = filename;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        URL.revokeObjectURL(url);
-    }
-
     // === Shrink header on scroll ===
     window.addEventListener('scroll', () => {
       const header = document.querySelector('.header-sticky');
@@ -1166,19 +820,12 @@
     }
     // Initialize dashboard
     function initDashboard() {
-        updateSectionIntro('overview');
-        // Generate dynamic components
         generateKPICards();
-
-        // Populate charts and tables
+        updateCaspsKpis();
         populateCountryChart();
         populateAuthorityChart();
         populateCaspsCountryChart();
         populateCaspsAuthorityChart();
-        populateCaspFilters();
-        populateDetailsTable();
-        populateCaspsTable();
-        populateNonCompliantTable();
     }
 
     function populateCountryChart() {
@@ -1285,537 +932,20 @@
         `).join('');
     }
 
-    function populateDetailsTable(dataToShow = filteredData) {
-        const tbody = document.getElementById('detailsTable');
-        const noResults = document.getElementById('noResults');
-
-        dataToShow = sortRows(dataToShow, sortStates.emt);
-
-        if (dataToShow.length === 0) {
-            tbody.innerHTML = '';
-            noResults.classList.remove('hidden');
-            return;
-        }
-
-        noResults.classList.add('hidden');
-        // Get all currency columns dynamically (once, not per row)
-        const currencyFields = getCurrencyFields(dataToShow);
-
-        tbody.innerHTML = dataToShow.map((item, index) => {
-            const currencyBadges = currencyFields
-                .filter(currency => item[currency] > 0)
-                .map(currency => {
-                    const currencyCode = currency.toUpperCase();
-                    return `<span class="px-2 py-1 rounded text-xs font-semibold" style="${getCurrencyBadgeStyle(currencyCode)}">${esc(currencyCode)}</span>`;
-                }).join(' ');
-
-            return `
-                <tr class="border-b hover:bg-gradient-to-r hover:from-teal-200 hover:to-blue-200 transition-all duration-200 ${index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}">
-                    <td class="p-4">
-                        <div class="font-semibold text-gray-800">${esc(item.issuer)}</div>
-                    </td>
-                    <td class="p-4">
-                        <span class="px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium">
-                            <span aria-hidden="true">${countryFlags[item.state] || '🏳️'}</span> ${esc(item.state)}
-                        </span>
-                    </td>
-                    <td class="p-4 text-gray-600 text-sm">${esc(item.authority)}</td>
-                    <td class="p-4">
-                        <div class="text-sm text-gray-800 font-mono">${esc(item.tokens || 'N/A')}</div>
-                    </td>
-                    <td class="p-4 text-center">
-                        <span class="px-3 py-1 rounded-full text-sm font-bold ${
-                            item.count > 1 ? 'bg-green-100 text-green-800' : 
-                            item.count === 1 ? 'bg-yellow-100 text-yellow-800' : 
-                            'bg-gray-100 text-gray-600'
-                        }">
-                            ${item.count}
-                        </span>
-                    </td>
-                    <td class="p-4 text-center">
-                        <div class="flex justify-center space-x-1">
-                            ${currencyBadges}
-                        </div>
-                    </td>
-                </tr>
-            `;
-        }).join('');
-    }
-
-    function populateCaspsTable(dataToShow = filteredCaspsData) {
-        const tbody = document.getElementById('caspsTable');
-        const noResults = document.getElementById('noCaspsResults');
-
-        dataToShow = sortRows(dataToShow, sortStates.casps);
-        updateCaspsKpis(dataToShow);
-
-        if (!tbody) {
-            return;
-        }
-
-        if (dataToShow.length === 0) {
-            tbody.innerHTML = '';
-            if (noResults) {
-                noResults.classList.remove('hidden');
-            }
-            return;
-        }
-
-        if (noResults) {
-            noResults.classList.add('hidden');
-        }
-
-        tbody.innerHTML = dataToShow.map((item, index) => {
-            const servicesBadges = (item.services || []).map(service => `
-                <span class="service-badge px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium">${esc(service)}</span>
-            `).join(' ');
-
-            const websiteBadges = (item.websites && item.websites.length > 0)
-                ? item.websites.map(site => {
-                    // Only link out to http(s) URLs; render anything else as text
-                    const url = safeHttpUrl(site);
-                    return url
-                        ? `<a href="${esc(url)}" target="_blank" rel="noopener" class="casps-website-link block text-sm text-blue-600 underline">${esc(site)}</a>`
-                        : `<span class="casps-website-link block text-sm text-gray-600">${esc(site)}</span>`;
-                }).join('')
-                : '<span class="text-xs text-gray-500">Not provided</span>';
-
-            return `
-                <tr class="border-b hover:bg-gradient-to-r hover:from-teal-200 hover:to-blue-200 transition-all duration-200">
-                    <td class="p-4 text-sm font-semibold text-gray-500">${index + 1}</td>
-                    <td class="p-4">
-                        <p class="text-gray-900 font-semibold">${esc(item.name || 'N/A')}</p>
-                    </td>
-                    <td class="p-4">
-                        <span class="casps-country-badge px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium">
-                            <span aria-hidden="true">${countryFlags[item.memberState] || '🏳️'}</span> ${esc(item.memberState || 'Unknown')}
-                        </span>
-                    </td>
-                    <td class="p-4 text-gray-600 text-sm casps-authority-cell">${esc(item.authority || '—')}</td>
-                    <td class="p-4 services-cell">
-                        <div class="service-badges">${servicesBadges || '<span class="text-xs text-gray-500">Not specified</span>'}</div>
-                    </td>
-                    <td class="p-4">
-                        <div class="space-y-1">${websiteBadges}</div>
-                    </td>
-                </tr>
-            `;
-        }).join('');
-    }
-
-    function updateNonCompliantNewSummary(dataToShow = filteredNonCompliantData) {
-        const summary = document.getElementById('nonCompliantNewSummary');
-        const toggle = document.getElementById('toggleNewNonCompliant');
-        const totalNew = nonCompliantData.filter(item => item.isNew).length;
-        const visibleNew = dataToShow.filter(item => item.isNew).length;
-
-        if (summary) {
-            summary.textContent = totalNew > 0
-                ? `${visibleNew} new flagged ${visibleNew === 1 ? 'entity is' : 'entities are'} visible (${totalNew} total marked new).`
-                : 'No entities are currently marked new in the latest dataset.';
-        }
-
-        if (toggle) {
-            toggle.setAttribute('aria-pressed', showNewNonCompliantOnly ? 'true' : 'false');
-            toggle.className = showNewNonCompliantOnly
-                ? 'px-3 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold whitespace-nowrap'
-                : 'px-3 py-2 text-sm bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200 transition-colors font-semibold whitespace-nowrap';
-        }
-    }
-
-    function populateNonCompliantTable(dataToShow = filteredNonCompliantData) {
-        const tbody = document.getElementById('nonCompliantTable');
-        const noResults = document.getElementById('noNonCompliantResults');
-
-        dataToShow = sortRows(dataToShow, sortStates.nonCompliant);
-        updateNonCompliantNewSummary(dataToShow);
-
-        if (dataToShow.length === 0) {
-            tbody.innerHTML = '';
-            noResults.classList.remove('hidden');
-            return;
-        }
-
-        noResults.classList.add('hidden');
-        tbody.innerHTML = dataToShow.map((item, index) => {
-            const rowBackground = item.isNew ? 'bg-blue-50' : (index % 2 === 0 ? 'bg-gray-50' : 'bg-white');
-
-            return `
-            <tr class="border-b hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 transition-all duration-200 ${rowBackground}">
-                <td class="p-4 text-sm font-semibold text-gray-500">${index + 1}</td>
-                <td class="p-4">
-                    <div class="font-semibold text-gray-800 flex items-center">
-                        <span>${esc(item.entity)}</span>
-                        ${item.isNew ? `
-                            <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold text-blue-700 bg-blue-100">
-                                <i class="fas fa-star text-blue-500 mr-1" aria-hidden="true"></i>New
-                            </span>
-                        ` : ''}
-                    </div>
-                </td>
-                <td class="p-4">
-                    <span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-medium">
-                        <span aria-hidden="true">${countryFlags[item.country] || '🏳️'}</span> ${esc(item.country)}
-                    </span>
-                </td>
-                <td class="p-4 text-gray-600 text-sm">${esc(item.authority)}</td>
-                <td class="p-4">
-                    <div class="space-y-1">
-                        ${item.websites.map(website => `
-                            <div class="text-xs text-blue-600 font-mono bg-blue-50 px-2 py-1 rounded">
-                                ${esc(website)}
-                            </div>
-                        `).join('')}
-                    </div>
-                </td>
-                <td class="p-4 text-center">
-                    <span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-bold" title="Flagged">
-                        <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-                        <span class="sr-only">Flagged</span>
-                    </span>
-                </td>
-            </tr>
-        `;
-        }).join('');
-    }
-
-    // Search functionality
-    function debounce(fn, wait = 150) {
-        let timer = null;
-        return (...args) => {
-            clearTimeout(timer);
-            timer = setTimeout(() => fn(...args), wait);
-        };
-    }
-
-    function filterData(searchTerm) {
-        if (!searchTerm.trim()) {
-            filteredData = [...data];
-        } else {
-            const term = searchTerm.toLowerCase();
-            filteredData = data.filter(item =>
-                item.issuer.toLowerCase().includes(term) ||
-                item.state.toLowerCase().includes(term) ||
-                item.authority.toLowerCase().includes(term) ||
-                item.tokens.toLowerCase().includes(term)
-            );
-        }
-        populateDetailsTable(filteredData);
-    }
-
-    // Fill the country/service dropdowns from the loaded CASP data
-    function populateCaspFilters() {
-        const countrySelect = document.getElementById('caspsCountryFilter');
-        const serviceSelect = document.getElementById('caspsServiceFilter');
-
-        if (countrySelect) {
-            const countries = [...new Set(caspsData.map(item => (item.memberState || '').trim()).filter(Boolean))]
-                .sort((a, b) => a.localeCompare(b, 'en'));
-            countrySelect.innerHTML = '<option value="">All countries</option>' +
-                countries.map(country => `<option value="${esc(country)}">${esc(country)}</option>`).join('');
-        }
-
-        if (serviceSelect) {
-            const services = [...new Set((caspsData.flatMap(item => item.services || [])).map(service => service.trim()).filter(Boolean))]
-                .sort((a, b) => a.localeCompare(b, 'en'));
-            serviceSelect.innerHTML = '<option value="">All services</option>' +
-                services.map(service => `<option value="${esc(service)}">${esc(service)}</option>`).join('');
-        }
-    }
-
-    function filterCaspsData(searchTerm) {
-        const term = (searchTerm || '').trim().toLowerCase();
-        const countryFilter = document.getElementById('caspsCountryFilter')?.value || '';
-        const serviceFilter = document.getElementById('caspsServiceFilter')?.value || '';
-
-        filteredCaspsData = caspsData.filter(item => {
-            const services = item.services || [];
-            const websites = (item.websites || []).join(' ').toLowerCase();
-
-            const matchesSearch = !term ||
-                (item.name || '').toLowerCase().includes(term) ||
-                (item.memberState || '').toLowerCase().includes(term) ||
-                (item.authority || '').toLowerCase().includes(term) ||
-                services.join(' ').toLowerCase().includes(term) ||
-                websites.includes(term);
-
-            const matchesCountry = !countryFilter || (item.memberState || '') === countryFilter;
-            const matchesService = !serviceFilter || services.includes(serviceFilter);
-
-            return matchesSearch && matchesCountry && matchesService;
-        });
-
-        populateCaspsTable(filteredCaspsData);
-    }
-
-    function filterNonCompliantData(searchTerm) {
-        const term = searchTerm.trim().toLowerCase();
-        filteredNonCompliantData = nonCompliantData.filter(item => {
-            const matchesSearch = !term ||
-                item.entity.toLowerCase().includes(term) ||
-                item.country.toLowerCase().includes(term) ||
-                item.authority.toLowerCase().includes(term) ||
-                item.websites.some(website => website.toLowerCase().includes(term));
-            const matchesNewFilter = !showNewNonCompliantOnly || item.isNew;
-
-            return matchesSearch && matchesNewFilter;
-        });
-
-        populateNonCompliantTable(filteredNonCompliantData);
-    }
-
-    // Tab switching functionality
-    const tabHashes = {
-        overview: '#overview',
-        details: '#details',
-        casps: '#casps',
-        nonCompliant: '#non-compliant'
+    // Legacy #tab bookmarks (pre-refactor the registers were tabs inside
+    // this page). Forward them to the standalone intent pages so any old
+    // shared link still lands on the right register.
+    const legacyHashRedirects = {
+        '#details': 'emt-tracker.html',
+        '#emts': 'emt-tracker.html',
+        '#casps': 'casp-tracker.html',
+        '#non-compliant': 'non-compliant-casps.html',
+        '#noncompliant': 'non-compliant-casps.html'
     };
-
-    function switchTab(tab) {
-        const overviewBtn = document.getElementById('overviewBtn');
-        const detailsBtn = document.getElementById('detailsBtn');
-        const nonCompliantBtn = document.getElementById('nonCompliantBtn');
-        const caspsBtn = document.getElementById('caspsBtn');
-        const overviewSection = document.getElementById('overviewSection');
-        const detailsSection = document.getElementById('detailsSection');
-        const caspsSection = document.getElementById('caspsSection');
-        const nonCompliantSection = document.getElementById('nonCompliantSection');
-
-        // Reset all buttons
-        [overviewBtn, detailsBtn, nonCompliantBtn, caspsBtn].forEach(btn => {
-            btn.className = 'tab-button tab-inactive px-5 py-3 rounded-xl font-semibold';
-            btn.setAttribute('aria-selected', 'false');
-            btn.setAttribute('tabindex', '-1');
-        });
-
-        // Hide all sections
-        [overviewSection, detailsSection, caspsSection, nonCompliantSection].forEach(section => {
-            section.classList.add('hidden');
-        });
-
-        updateSectionIntro(tab);
-
-        // Show selected tab
-        let activeBtn = null;
-        if (tab === 'overview') {
-            activeBtn = overviewBtn;
-            overviewSection.classList.remove('hidden');
-        } else if (tab === 'details') {
-            activeBtn = detailsBtn;
-            detailsSection.classList.remove('hidden');
-        } else if (tab === 'casps') {
-            activeBtn = caspsBtn;
-            caspsSection.classList.remove('hidden');
-        } else if (tab === 'nonCompliant') {
-            activeBtn = nonCompliantBtn;
-            nonCompliantSection.classList.remove('hidden');
-        }
-
-        if (activeBtn) {
-            activeBtn.className = 'tab-button tab-active px-5 py-3 rounded-xl font-semibold';
-            activeBtn.setAttribute('aria-selected', 'true');
-            activeBtn.setAttribute('tabindex', '0');
-        }
-
-        // Keep the URL shareable: reflect the active tab in the hash.
-        // replaceState avoids a hashchange event and history spam.
-        const targetHash = tabHashes[tab];
-        if (targetHash && window.location.hash !== targetHash) {
-            history.replaceState(null, '', targetHash);
-        }
-
-        window.scrollTo({ top: 0, behavior: 'auto' });
+    const legacyTarget = legacyHashRedirects[window.location.hash.toLowerCase()];
+    if (legacyTarget) {
+        window.location.replace(legacyTarget);
     }
-
-
-
-    function applyHashRouting() {
-        const hash = window.location.hash.replace('#', '').toLowerCase();
-        const map = {
-            'overview': 'overview',
-            'details': 'details',
-            'casps': 'casps',
-            'non-compliant': 'nonCompliant',
-            'noncompliant': 'nonCompliant'
-        };
-        const tab = map[hash];
-        if (!tab) {
-            return;
-        }
-        switchTab(tab);
-        window.scrollTo({ top: 0, behavior: 'auto' });
-    }
-
-    function resetDashboard() {
-        switchTab('overview');
-
-        const searchInput = document.getElementById('searchInput');
-        if (searchInput) {
-            searchInput.value = '';
-        }
-        filteredData = [...data];
-        populateDetailsTable(filteredData);
-
-        const caspsSearchInput = document.getElementById('caspsSearchInput');
-        if (caspsSearchInput) {
-            caspsSearchInput.value = '';
-        }
-        const caspsCountryFilter = document.getElementById('caspsCountryFilter');
-        if (caspsCountryFilter) {
-            caspsCountryFilter.value = '';
-        }
-        const caspsServiceFilter = document.getElementById('caspsServiceFilter');
-        if (caspsServiceFilter) {
-            caspsServiceFilter.value = '';
-        }
-        filteredCaspsData = [...caspsData];
-        populateCaspsTable(filteredCaspsData);
-
-        const nonCompliantSearchInput = document.getElementById('nonCompliantSearchInput');
-        if (nonCompliantSearchInput) {
-            nonCompliantSearchInput.value = '';
-        }
-        filteredNonCompliantData = [...nonCompliantData];
-        showNewNonCompliantOnly = false;
-        populateNonCompliantTable(filteredNonCompliantData);
-    }
-
-    // Event listeners
-    document.getElementById('overviewBtn').addEventListener('click', () => switchTab('overview'));
-    document.getElementById('detailsBtn').addEventListener('click', () => switchTab('details'));
-    document.getElementById('caspsBtn').addEventListener('click', () => switchTab('casps'));
-    document.getElementById('nonCompliantBtn').addEventListener('click', () => switchTab('nonCompliant'));
-
-    initSortableHeaders('detailsTable', sortStates.emt, () => populateDetailsTable(filteredData));
-    initSortableHeaders('caspsTable', sortStates.casps, () => populateCaspsTable(filteredCaspsData));
-    initSortableHeaders('nonCompliantTable', sortStates.nonCompliant, () => populateNonCompliantTable(filteredNonCompliantData));
-
-    document.getElementById('exportEmtCsv').addEventListener('click', () => {
-        const currencyColumns = getCurrencyFields(data).map(currency => ({
-            label: currency.toUpperCase(),
-            value: row => row[currency] || 0
-        }));
-        downloadCsv('micar-emts.csv', [
-            { label: 'Issuer', value: row => row.issuer },
-            { label: 'Country', value: row => row.state },
-            { label: 'Authority', value: row => row.authority },
-            { label: 'Tokens', value: row => row.tokens },
-            { label: 'Count', value: row => row.count },
-            ...currencyColumns
-        ], sortRows(filteredData, sortStates.emt));
-    });
-
-    document.getElementById('exportCaspsCsv').addEventListener('click', () => {
-        downloadCsv('micar-casps.csv', [
-            { label: 'CASP', value: row => row.name },
-            { label: 'Country', value: row => row.memberState },
-            { label: 'Competent Authority', value: row => row.authority },
-            { label: 'Services', value: row => (row.services || []).join('; ') },
-            { label: 'Websites', value: row => (row.websites || []).join('; ') }
-        ], sortRows(filteredCaspsData, sortStates.casps));
-    });
-
-    document.getElementById('exportNonCompliantCsv').addEventListener('click', () => {
-        downloadCsv('micar-non-compliant.csv', [
-            { label: 'Entity', value: row => row.entity },
-            { label: 'Country', value: row => row.country },
-            { label: 'Regulatory Authority', value: row => row.authority },
-            { label: 'Websites', value: row => (row.websites || []).join('; ') },
-            { label: 'New', value: row => (row.isNew ? 'yes' : 'no') }
-        ], sortRows(filteredNonCompliantData, sortStates.nonCompliant));
-    });
-
-    // Arrow-key navigation between tabs (WAI-ARIA tabs pattern)
-    const dashboardTablist = document.getElementById('dashboardTablist');
-    if (dashboardTablist) {
-        const tabOrder = ['overview', 'details', 'casps', 'nonCompliant'];
-        const tabButtons = ['overviewBtn', 'detailsBtn', 'caspsBtn', 'nonCompliantBtn']
-            .map(id => document.getElementById(id));
-
-        dashboardTablist.addEventListener('keydown', (event) => {
-            const currentIndex = tabButtons.indexOf(document.activeElement);
-            if (currentIndex === -1) {
-                return;
-            }
-
-            let nextIndex = null;
-            if (event.key === 'ArrowRight') {
-                nextIndex = (currentIndex + 1) % tabButtons.length;
-            } else if (event.key === 'ArrowLeft') {
-                nextIndex = (currentIndex - 1 + tabButtons.length) % tabButtons.length;
-            } else if (event.key === 'Home') {
-                nextIndex = 0;
-            } else if (event.key === 'End') {
-                nextIndex = tabButtons.length - 1;
-            }
-
-            if (nextIndex !== null) {
-                event.preventDefault();
-                switchTab(tabOrder[nextIndex]);
-                tabButtons[nextIndex].focus();
-            }
-        });
-    }
-
-    const homeLogo = document.getElementById('homeLogo');
-    if (homeLogo) {
-        const handleDashboardReset = (event) => {
-            event.preventDefault();
-            resetDashboard();
-        };
-
-        homeLogo.addEventListener('click', handleDashboardReset);
-        homeLogo.addEventListener('keydown', (event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
-                handleDashboardReset(event);
-            }
-        });
-    }
-
-    // Debounced: each keystroke otherwise rebuilds the whole table
-    const debouncedFilterData = debounce(filterData);
-    document.getElementById('searchInput').addEventListener('input', (e) => {
-        debouncedFilterData(e.target.value);
-    });
-
-    document.getElementById('clearSearch').addEventListener('click', () => {
-        document.getElementById('searchInput').value = '';
-        filterData('');
-    });
-
-    const debouncedFilterCaspsData = debounce(filterCaspsData);
-    document.getElementById('caspsSearchInput').addEventListener('input', (e) => {
-        debouncedFilterCaspsData(e.target.value);
-    });
-
-    // Dropdowns apply immediately, combined with the current search term
-    const reapplyCaspsFilters = () => filterCaspsData(document.getElementById('caspsSearchInput').value);
-    document.getElementById('caspsCountryFilter').addEventListener('change', reapplyCaspsFilters);
-    document.getElementById('caspsServiceFilter').addEventListener('change', reapplyCaspsFilters);
-
-    document.getElementById('clearCaspsSearch').addEventListener('click', () => {
-        document.getElementById('caspsSearchInput').value = '';
-        document.getElementById('caspsCountryFilter').value = '';
-        document.getElementById('caspsServiceFilter').value = '';
-        filterCaspsData('');
-    });
-
-    const debouncedFilterNonCompliantData = debounce(filterNonCompliantData);
-    document.getElementById('nonCompliantSearchInput').addEventListener('input', (e) => {
-        debouncedFilterNonCompliantData(e.target.value);
-    });
-
-    document.getElementById('toggleNewNonCompliant').addEventListener('click', () => {
-        showNewNonCompliantOnly = !showNewNonCompliantOnly;
-        filterNonCompliantData(document.getElementById('nonCompliantSearchInput').value);
-    });
-
-    document.getElementById('clearNonCompliantSearch').addEventListener('click', () => {
-        document.getElementById('nonCompliantSearchInput').value = '';
-        showNewNonCompliantOnly = false;
-        filterNonCompliantData('');
-    });
 
     // Initialize on page load
     async function bootDashboard() {
@@ -1834,13 +964,11 @@
         if (loadingNotice) loadingNotice.classList.add('hidden');
         computeAggregates();
         initDashboard();
-        applyHashRouting();
         loadChangelog();
         loadSnapshotInfo();
     }
 
     document.addEventListener('DOMContentLoaded', bootDashboard);
-    window.addEventListener('hashchange', applyHashRouting);
     </script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {

--- a/index.html
+++ b/index.html
@@ -102,119 +102,14 @@
     .kpi-green { --start-color: #10b981; --end-color: #059669; }
     .kpi-yellow { --start-color: #f59e0b; --end-color: #d97706; }
 
-    .search-input {
-    background: rgba(255, 255, 255, 0.9);
-    backdrop-filter: blur(10px);
-    }
-
     .content-bg {
     background: rgba(255, 255, 255, 0.05);
     backdrop-filter: blur(10px);
     }
 
-
-    .data-table-container {
-    /* clip (not hidden/auto) does not create a scroll container, so the
-       sticky column headers stick to the viewport instead of this box */
-    overflow-x: clip;
-    }
-
-    .data-table {
-    border-collapse: separate;
-    border-spacing: 0;
-    table-layout: auto;
-    min-width: 0;
-    width: 100%;
-    }
-
-    .data-table th,
-    .data-table td {
-    vertical-align: top;
-    overflow-wrap: anywhere;
-    }
-
-    .sticky-table-header th {
-    position: sticky;
-    /* pin just below the site header, whose height changes on scroll */
-    top: var(--site-header-height, 0px);
-    z-index: 20;
-    box-shadow: 0 1px 0 rgba(148, 163, 184, 0.35), 0 8px 16px -16px rgba(15, 23, 42, 0.55);
-    }
-
-    .sort-button {
-    font: inherit;
-    color: inherit;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.25rem;
-    }
-
-    .sort-button:hover,
-    .sort-button:focus-visible {
-    text-decoration: underline;
-    }
-
-    .sort-indicator {
-    font-size: 0.7em;
-    }
-
-    .sticky-table-header.teal th {
-    background: #f0fdfa;
-    }
-
-    .sticky-table-header.red th {
-    background: #fff7ed;
-    }
-
-    .services-cell {
-    min-width: 300px;
-    }
-
-    .service-badges {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    gap: 0.5rem;
-    max-width: 34rem;
-    }
-
-    .service-badge {
-    display: inline-flex;
-    align-items: center;
-    white-space: nowrap;
-    }
-
-    .casps-data-table {
-    table-layout: fixed;
-    }
-
-    .casps-data-table th,
-    .casps-data-table td {
-    overflow-wrap: normal;
-    word-break: normal;
-    }
-
-    .casps-country-badge,
-    .casps-authority-cell {
-    white-space: nowrap;
-    }
-
-    .casps-website-link {
-    overflow-wrap: anywhere;
-    word-break: break-word;
-    }
-
-    @media (max-width: 768px) {
-    .data-table th,
-    .data-table td {
-        padding-left: 0.75rem;
-        padding-right: 0.75rem;
-    }
-    }
+    /* Register table styles (data-table, sticky headers, sort buttons,
+       search-input, badges) live in styles/site.css - shared with the
+       casp-tracker / emt-tracker / non-compliant-casps pages */
     </style>
 </head>
 <body class="main-bg">
@@ -307,16 +202,16 @@
 
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
     <!-- Static, crawlable intro: keyword-rich text + links to the intent pages -->
-    <section class="mb-8 text-white">
-    <h2 class="text-2xl md:text-3xl font-bold mb-3">Search the ESMA MiCA register</h2>
-    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    <section class="mb-6 text-white">
+    <h2 class="text-2xl md:text-3xl font-bold mb-2">Search the ESMA MiCA register</h2>
+    <p class="text-blue-100 text-sm md:text-base">
     The DEA MiCAR Tracker presents the EU's <strong>Markets in Crypto-Assets (MiCA / MiCAR)</strong> registers in one searchable place, based on public data from the ESMA interim MiCA register. Browse MiCA-authorised
     <a href="casp-tracker.html" class="underline hover:text-white">Crypto-Asset Service Providers (CASPs)</a>,
     <a href="emt-tracker.html" class="underline hover:text-white">e-money token (EMT) issuers</a>, and
     <a href="non-compliant-casps.html" class="underline hover:text-white">entities flagged as non-compliant</a>
     by country, competent authority, services and token. Updated weekly; download any register as CSV or JSON.
     </p>
-    <ul class="mt-4 flex flex-wrap gap-3 text-sm font-semibold">
+    <ul class="mt-3 flex flex-wrap gap-3 text-sm font-semibold">
     <li><a href="casp-tracker.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">CASP Tracker</a></li>
     <li><a href="emt-tracker.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">EMT Tracker</a></li>
     <li><a href="non-compliant-casps.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">Non-Compliant CASPs</a></li>

--- a/index.html
+++ b/index.html
@@ -5,19 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="google-site-verification" content="CGGJidmg9parYMdFHNi4jklzZ7ul8ciafDiIBtup_nY" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev; object-src 'none'; base-uri 'self'; form-action 'self'">
-    <title>DEA MiCAR Tracker - Track Electronic Money Token (EMT) issuers and Crypto Asset Service Providers (CASPs) across Europe</title>
+    <title>MiCAR Tracker — ESMA MiCA Register for CASPs, EMTs & Non-Compliant Entities</title>
+    <meta name="description" content="Search the ESMA interim MiCA register in one place: MiCA-authorised CASPs, e-money token (EMT) issuers and non-compliant entities by country, authority and service. Updated weekly by the Digital Euro Association. Free CSV/JSON download.">
+    <link rel="canonical" href="https://micatracker.digital-euro-association.de/">
     <!-- Open Graph metadata -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://micatracker.digital-euro-association.de/">
-    <meta property="og:title" content="DEA MiCAR Tracker - Track Electronic Money Token (EMT) issuers and Crypto Asset Service Providers (CASPs) across Europe">
-    <meta property="og:description" content="Track Electronic Money Token (EMT) issuers and Crypto Asset Service Providers (CASPs) across Europe.">
+    <meta property="og:title" content="MiCAR Tracker — ESMA MiCA Register for CASPs, EMTs & Non-Compliant Entities">
+    <meta property="og:description" content="Search the ESMA interim MiCA register: MiCA-authorised CASPs, EMT issuers and non-compliant entities by country, authority and service. Updated weekly.">
     <meta property="og:image" content="https://micatracker.digital-euro-association.de/cover.png">
 
     <!-- Twitter Card metadata -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://micatracker.digital-euro-association.de/">
-    <meta name="twitter:title" content="DEA MiCAR Tracker - Track Electronic Money Token (EMT) issuers and Crypto Asset Service Providers (CASPs) across Europe">
-    <meta name="twitter:description" content="Track Electronic Money Token (EMT) issuers and Crypto Asset Service Providers (CASPs) across Europe.">
+    <meta name="twitter:title" content="MiCAR Tracker — ESMA MiCA Register for CASPs, EMTs & Non-Compliant Entities">
+    <meta name="twitter:description" content="Search the ESMA interim MiCA register: MiCA-authorised CASPs, EMT issuers and non-compliant entities by country, authority and service. Updated weekly.">
     <meta name="twitter:image" content="https://micatracker.digital-euro-association.de/cover.png">
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="alternate" type="application/rss+xml" title="MiCAR Tracker register updates" href="feed.xml">
@@ -304,6 +306,23 @@
     </div>
 
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
+    <!-- Static, crawlable intro: keyword-rich text + links to the intent pages -->
+    <section class="mb-8 text-white">
+    <h2 class="text-2xl md:text-3xl font-bold mb-3">Search the ESMA MiCA register</h2>
+    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    The DEA MiCAR Tracker presents the EU's <strong>Markets in Crypto-Assets (MiCA / MiCAR)</strong> registers in one searchable place, based on public data from the ESMA interim MiCA register. Browse MiCA-authorised
+    <a href="casp-tracker.html" class="underline hover:text-white">Crypto-Asset Service Providers (CASPs)</a>,
+    <a href="emt-tracker.html" class="underline hover:text-white">e-money token (EMT) issuers</a>, and
+    <a href="non-compliant-casps.html" class="underline hover:text-white">entities flagged as non-compliant</a>
+    by country, competent authority, services and token. Updated weekly; download any register as CSV or JSON.
+    </p>
+    <ul class="mt-4 flex flex-wrap gap-3 text-sm font-semibold">
+    <li><a href="casp-tracker.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">CASP Tracker</a></li>
+    <li><a href="emt-tracker.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">EMT Tracker</a></li>
+    <li><a href="non-compliant-casps.html" class="inline-block bg-white/15 hover:bg-white/25 rounded-lg px-4 py-2 transition-colors">Non-Compliant CASPs</a></li>
+    </ul>
+    </section>
+
     <div id="sectionIntro" class="mb-6 text-white space-y-4 md:space-y-6">
     <h2 id="sectionTitle" class="text-2xl font-semibold">EMT Issuer Insights</h2>
     <p id="sectionDescription" class="text-blue-100">Key indicators and distributions for licensed Electronic Money Token issuers.</p>
@@ -596,9 +615,20 @@
 
         <!-- ── Nav links + social icons ── -->
         <div class="flex flex-col md:flex-row md:justify-between gap-8">
+          <!-- Registers -->
+          <nav aria-label="Registers">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Registers</p>
+            <ul class="space-y-2 text-sm">
+              <li><a href="casp-tracker.html" class="hover:text-white font-semibold">CASP Tracker</a></li>
+              <li><a href="emt-tracker.html" class="hover:text-white font-semibold">EMT Tracker</a></li>
+              <li><a href="non-compliant-casps.html" class="hover:text-white font-semibold">Non-Compliant CASPs</a></li>
+              <li><a href="about.html" class="hover:text-white font-semibold">About &amp; methodology</a></li>
+            </ul>
+          </nav>
           <!-- Nav -->
-          <nav>
-            <ul class="space-y-2 md:space-y-0 md:flex md:gap-6 text-sm">
+          <nav aria-label="Legal">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Digital Euro Association</p>
+            <ul class="space-y-2 text-sm">
               <li><a href="https://home.digital-euro-association.de/legal-notice?hsLang=en"  target="_blank" rel="noopener" class="hover:text-white font-semibold">Legal Notice</a></li>
               <li><a href="https://home.digital-euro-association.de/privacy-policy-0?hsLang=en" target="_blank" rel="noopener" class="hover:text-white font-semibold">Privacy</a></li>
               <li><a href="https://home.digital-euro-association.de/code-of-conduct?hsLang=en"  target="_blank" rel="noopener" class="hover:text-white font-semibold">Code of Conduct</a></li>

--- a/non-compliant-casps.html
+++ b/non-compliant-casps.html
@@ -129,7 +129,7 @@
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
     <section class="mb-8 text-white">
     <h2 class="text-2xl md:text-3xl font-bold mb-3">Non-Compliant CASPs</h2>
-    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    <p class="text-blue-100 leading-relaxed">
     View <strong>entities flagged as non-compliant</strong> by European regulators under the EU's Markets in Crypto-Assets Regulation (MiCA / MiCAR), using public data from the ESMA interim MiCA register. Search by entity name, country and regulatory authority. Please do not visit the listed websites — many are suspected of hosting phishing or other malicious content, so they are shown as plain text and are not clickable. Updated weekly by the Digital Euro Association.
     </p>
     <p id="rvFreshness" class="text-sm text-blue-100 mt-3"></p>

--- a/non-compliant-casps.html
+++ b/non-compliant-casps.html
@@ -75,10 +75,56 @@
         <a href="non-compliant-casps.html" class="tab-button tab-active px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant</a>
         <a href="about.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-circle-info mr-2" aria-hidden="true"></i>About</a>
       </nav>
+      <div class="md:hidden flex items-center hamburger-only">
+        <button id="mobile-menu-button"
+                type="button"
+                class="hamburger-button text-white hover:text-sky-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white"
+                aria-controls="mobile-menu"
+                aria-expanded="false"
+                aria-label="Open main menu">
+          <svg id="hamburger-icon" class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <svg id="close-icon" class="h-6 w-6 hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
     </div>
     </div>
     </div>
     </header>
+
+    <div id="mobile-menu-overlay" class="mobile-menu-overlay fixed inset-0 hidden" aria-hidden="true"></div>
+
+    <div id="mobile-menu" class="mobile-menu-container hidden">
+      <div class="mobile-menu-panel p-4">
+        <nav class="flex flex-col mobile-menu-list" aria-label="Mobile navigation">
+          <a href="index.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-chart-pie"></i></span>
+            <span class="mobile-menu-text">Overview</span>
+          </a>
+          <a href="emt-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-table"></i></span>
+            <span class="mobile-menu-text">EMTs</span>
+          </a>
+          <a href="casp-tracker.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-building-columns"></i></span>
+            <span class="mobile-menu-text">CASPs</span>
+          </a>
+          <a href="non-compliant-casps.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-exclamation-triangle"></i></span>
+            <span class="mobile-menu-text">Non-Compliant</span>
+          </a>
+          <a href="about.html" class="mobile-menu-link mobile-menu-item text-base font-medium">
+            <span class="mobile-menu-icon" aria-hidden="true"><i class="fas fa-circle-info"></i></span>
+            <span class="mobile-menu-text">About</span>
+          </a>
+        </nav>
+      </div>
+    </div>
 
     <main id="main" class="max-w-7xl mx-auto px-6 py-8">
     <section class="mb-8 text-white">
@@ -148,6 +194,15 @@
     </footer>
     <!-- ==== DEA FOOTER END ==== -->
 
+    <script>
+      window.addEventListener('scroll', function () {
+        var header = document.querySelector('.header-sticky');
+        if (!header) return;
+        if (window.scrollY > 20) header.classList.add('shrink');
+        else header.classList.remove('shrink');
+      });
+    </script>
+    <script src="assets/js/mobile-menu.js" defer></script>
     <script src="assets/js/register-view.js" defer></script>
     <script>
       document.addEventListener('DOMContentLoaded', function () {

--- a/non-compliant-casps.html
+++ b/non-compliant-casps.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev; object-src 'none'; base-uri 'self'; form-action 'self'">
+    <title>Non-Compliant CASPs — Entities Flagged Under MiCA (ESMA Register)</title>
+    <meta name="description" content="View entities flagged as non-compliant under MiCA using ESMA register data. Search non-compliant crypto providers by entity name, country and regulatory authority. Updated weekly by the Digital Euro Association.">
+    <link rel="canonical" href="https://micatracker.digital-euro-association.de/non-compliant-casps.html">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://micatracker.digital-euro-association.de/non-compliant-casps.html">
+    <meta property="og:title" content="Non-Compliant CASPs — Entities Flagged Under MiCA (ESMA Register)">
+    <meta property="og:description" content="Entities flagged as non-compliant under MiCA, from ESMA register data. Search by entity name, country and regulatory authority. Updated weekly.">
+    <meta property="og:image" content="https://micatracker.digital-euro-association.de/cover.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Non-Compliant CASPs — Entities Flagged Under MiCA (ESMA Register)">
+    <meta name="twitter:description" content="Entities flagged as non-compliant under MiCA, from ESMA register data. Search by entity name, country and regulatory authority. Updated weekly.">
+    <meta name="twitter:image" content="https://micatracker.digital-euro-association.de/cover.png">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="alternate" type="application/rss+xml" title="MiCAR Tracker register updates" href="feed.xml">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      "name": "Entities flagged as non-compliant under MiCA",
+      "description": "Entities flagged by European regulators as providing crypto-asset services in non-compliance with the EU Markets in Crypto-Assets Regulation (MiCAR), derived from the ESMA interim MiCA register. Includes entity name, country and regulatory authority.",
+      "url": "https://micatracker.digital-euro-association.de/casp-tracker.html",
+      "keywords": ["non-compliant", "MiCA", "MiCAR", "crypto scam", "ESMA", "warning list"],
+      "creator": { "@type": "Organization", "name": "Digital Euro Association", "url": "https://digital-euro-association.de" },
+      "isBasedOn": "https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister",
+      "distribution": [
+        { "@type": "DataDownload", "encodingFormat": "application/json", "contentUrl": "https://micatracker.digital-euro-association.de/data/non-compliant.json" }
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        { "@type": "Question", "name": "What does non-compliant mean under MiCAR?", "acceptedAnswer": { "@type": "Answer", "text": "These are entities flagged by EU national competent authorities or ESMA as providing crypto-asset services without the authorisation required under the EU Markets in Crypto-Assets Regulation." } },
+        { "@type": "Question", "name": "Where does this data come from?", "acceptedAnswer": { "@type": "Answer", "text": "It uses public ESMA interim MiCA register data on non-compliant entities, presented in a clearer, searchable format." } },
+        { "@type": "Question", "name": "How often is this updated?", "acceptedAnswer": { "@type": "Answer", "text": "It is updated weekly based on the latest processed ESMA register data." } },
+        { "@type": "Question", "name": "Should I visit the listed websites?", "acceptedAnswer": { "@type": "Answer", "text": "No. Many listed sites are suspected of hosting phishing or other malicious content. Websites are shown as plain text and are not clickable. Verify status against ESMA or the relevant national authority." } }
+      ]
+    }
+    </script>
+    <link rel="stylesheet" href="styles/tailwind.css">
+    <link rel="stylesheet" href="styles/site.css">
+    <link rel="stylesheet" href="assets/vendor/inter/inter.css">
+    <link rel="stylesheet" href="assets/vendor/fontawesome/css/all.min.css">
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="dbd82f5d-689a-452f-9fff-fba85b9de507"></script>
+</head>
+<body class="main-bg">
+    <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-900 focus:font-semibold focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-lg">Skip to main content</a>
+    <header class="header-sticky shadow-2xl">
+    <div class="max-w-7xl mx-auto px-6 py-6">
+    <div class="flex items-center justify-between flex-wrap header-content">
+    <div class="flex items-center space-x-6 mb-4 md:mb-0">
+        <a href="index.html" class="inline-flex items-center" aria-label="Return to the dashboard">
+        <img src="DEA%20logo%20white.png" alt="DEA Logo" class="logo-container">
+        </a>
+        <div class="flex items-center">
+            <h1 class="text-[1.8rem] md:text-[2.2rem] font-bold text-white mb-0 leading-tight">
+                <span class="text-sky-100">MiCAR</span>
+                <span class="text-sky-50">Tracker</span>
+            </h1>
+        </div>
+    </div>
+    <div class="flex items-center gap-3 header-actions">
+      <nav class="hidden md:flex items-center nav-buttons" aria-label="Main navigation">
+        <a href="index.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-chart-pie mr-2" aria-hidden="true"></i>Overview</a>
+        <a href="emt-tracker.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-table mr-2" aria-hidden="true"></i>EMTs</a>
+        <a href="casp-tracker.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-building-columns mr-2" aria-hidden="true"></i>CASPs</a>
+        <a href="non-compliant-casps.html" class="tab-button tab-active px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-exclamation-triangle mr-2" aria-hidden="true"></i>Non-Compliant</a>
+        <a href="about.html" class="tab-button tab-inactive px-5 py-3 rounded-xl font-semibold inline-flex items-center justify-center"><i class="fas fa-circle-info mr-2" aria-hidden="true"></i>About</a>
+      </nav>
+    </div>
+    </div>
+    </div>
+    </header>
+
+    <main id="main" class="max-w-7xl mx-auto px-6 py-8">
+    <section class="mb-8 text-white">
+    <h2 class="text-2xl md:text-3xl font-bold mb-3">Non-Compliant CASPs</h2>
+    <p class="text-blue-100 max-w-3xl leading-relaxed">
+    View <strong>entities flagged as non-compliant</strong> by European regulators under the EU's Markets in Crypto-Assets Regulation (MiCA / MiCAR), using public data from the ESMA interim MiCA register. Search by entity name, country and regulatory authority. Please do not visit the listed websites — many are suspected of hosting phishing or other malicious content, so they are shown as plain text and are not clickable. Updated weekly by the Digital Euro Association.
+    </p>
+    <p id="rvFreshness" class="text-sm text-blue-100 mt-3"></p>
+    </section>
+
+    <div id="registerRoot" data-register="nonCompliant">
+    <div class="rounded-2xl bg-white bg-opacity-90 p-4 text-gray-700 text-sm">Loading non-compliant register&hellip;</div>
+    </div>
+
+    <section class="mt-10 bg-white bg-opacity-95 backdrop-filter backdrop-blur-lg rounded-2xl shadow-lg p-6 md:p-8 text-gray-700">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4">Non-Compliant CASPs FAQ</h2>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">What does non-compliant mean under MiCAR?</h3>
+    <p class="mt-1 leading-relaxed">These are entities flagged by EU national competent authorities or ESMA as providing crypto-asset services without the authorisation required under the EU Markets in Crypto-Assets Regulation. Inclusion is based on public regulator data.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">Where does the CASP Tracker data come from?</h3>
+    <p class="mt-1 leading-relaxed">It uses public data from the <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-600 underline">ESMA interim MiCA register</a>, presented in a clearer, searchable format. See the <a href="about.html" class="text-blue-600 underline">methodology</a> for details.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">Should I visit the listed websites?</h3>
+    <p class="mt-1 leading-relaxed">No. Many listed sites are suspected of hosting phishing or other malicious content. For your safety the websites are shown as plain text and are deliberately not clickable.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">How often is it updated?</h3>
+    <p class="mt-1 leading-relaxed">Weekly, based on the latest processed ESMA register data. The snapshot date is shown above the table.</p>
+    <h3 class="text-lg font-semibold text-gray-800 mt-4">Can I use this instead of the official ESMA register?</h3>
+    <p class="mt-1 leading-relaxed">No. The tracker is a first-look tool. Always verify an entity's status against ESMA or the relevant national competent authority. If you believe a listing is in error, contact the DEA using the details in the footer.</p>
+    </section>
+    </main>
+
+    <!-- ==== DEA FOOTER START ==== -->
+    <footer class="bg-gray-900 text-gray-200 mt-12">
+      <div class="max-w-7xl mx-auto px-4 py-10 space-y-10">
+        <div class="text-center">
+          <p class="text-gray-300">Digital Euro Association (DEA) MiCAR Tracker</p>
+          <p class="text-gray-400 text-sm mt-2">Source: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister" target="_blank" rel="noopener" class="text-blue-300 underline hover:text-blue-200">ESMA interim MiCA register</a></p>
+        </div>
+        <div class="flex flex-col md:flex-row md:justify-between gap-8">
+          <nav aria-label="Registers">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Registers</p>
+            <ul class="space-y-2 text-sm">
+              <li><a href="casp-tracker.html" class="hover:text-white font-semibold">CASP Tracker</a></li>
+              <li><a href="emt-tracker.html" class="hover:text-white font-semibold">EMT Tracker</a></li>
+              <li><a href="non-compliant-casps.html" class="hover:text-white font-semibold">Non-Compliant CASPs</a></li>
+              <li><a href="index.html" class="hover:text-white font-semibold">Full dashboard</a></li>
+            </ul>
+          </nav>
+          <nav aria-label="Legal">
+            <p class="text-gray-400 text-xs uppercase tracking-wide mb-2">Digital Euro Association</p>
+            <ul class="space-y-2 text-sm">
+              <li><a href="https://home.digital-euro-association.de/legal-notice?hsLang=en"  target="_blank" rel="noopener" class="hover:text-white font-semibold">Legal Notice</a></li>
+              <li><a href="https://home.digital-euro-association.de/privacy-policy-0?hsLang=en" target="_blank" rel="noopener" class="hover:text-white font-semibold">Privacy</a></li>
+              <li><a href="https://home.digital-euro-association.de/impressum?hsLang=en"      target="_blank" rel="noopener" class="hover:text-white font-semibold">Impressum</a></li>
+            </ul>
+          </nav>
+          <div class="flex items-start gap-6 text-xl">
+            <a href="https://x.com/DigiEuro" target="_blank" rel="noopener" aria-label="Twitter" class="hover:text-white"><i class="fab fa-twitter" aria-hidden="true"></i></a>
+            <a href="mailto:info@digital-euro-association.de" aria-label="Email" class="hover:text-white"><i class="fas fa-envelope" aria-hidden="true"></i></a>
+            <a href="https://www.linkedin.com/company/digital-euro-association/" target="_blank" rel="noopener" aria-label="LinkedIn" class="hover:text-white"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
+            <a href="https://github.com/DigiEuro/micardashboard" target="_blank" rel="noopener" aria-label="GitHub" class="hover:text-white"><i class="fab fa-github" aria-hidden="true"></i></a>
+          </div>
+        </div>
+        <div class="border-t border-gray-700 pt-6 flex flex-col md:flex-row md:justify-between md:items-center gap-4">
+          <p class="text-xs">&copy; <span id="year"></span> Digital Euro Association e.V.</p>
+          <a href="https://digital-euro-association.de" class="inline-block bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-5 py-2 rounded-lg shadow transition">Learn more about DEA</a>
+        </div>
+      </div>
+    </footer>
+    <!-- ==== DEA FOOTER END ==== -->
+
+    <script src="assets/js/register-view.js" defer></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        var y = document.getElementById('year');
+        if (y) y.textContent = new Date().getFullYear();
+      });
+    </script>
+    <script type="module" defer>
+      import { polyfillCountryFlagEmojis } from './assets/vendor/flags/country-flag-emoji-polyfill.mjs';
+      polyfillCountryFlagEmojis('Twemoji Country Flags', 'assets/vendor/flags/TwemojiCountryFlags.woff2');
+    </script>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://micatracker.digital-euro-association.de/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://micatracker.digital-euro-association.de/</loc>
+    <lastmod>2026-07-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://micatracker.digital-euro-association.de/casp-tracker.html</loc>
+    <lastmod>2026-07-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://micatracker.digital-euro-association.de/emt-tracker.html</loc>
+    <lastmod>2026-07-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://micatracker.digital-euro-association.de/non-compliant-casps.html</loc>
+    <lastmod>2026-07-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://micatracker.digital-euro-association.de/about.html</loc>
+    <lastmod>2026-07-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/styles/site.css
+++ b/styles/site.css
@@ -441,3 +441,117 @@ body {
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
 }
+
+/* ============================================================
+   Shared register table UI (dashboard + intent pages)
+   Moved from index.html's inline styles so casp-tracker.html,
+   emt-tracker.html and non-compliant-casps.html get the same
+   table styling, including the viewport-sticky column headers.
+   ============================================================ */
+.search-input {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+}
+
+.data-table-container {
+  /* clip (not hidden/auto) does not create a scroll container, so the
+     sticky column headers stick to the viewport instead of this box */
+  overflow-x: clip;
+}
+
+.data-table {
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: auto;
+  min-width: 0;
+  width: 100%;
+}
+
+.data-table th,
+.data-table td {
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+.sticky-table-header th {
+  position: sticky;
+  /* pin just below the site header, whose height changes on scroll */
+  top: var(--site-header-height, 0px);
+  z-index: 20;
+  box-shadow: 0 1px 0 rgba(148, 163, 184, 0.35), 0 8px 16px -16px rgba(15, 23, 42, 0.55);
+}
+
+.sort-button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.sort-button:hover,
+.sort-button:focus-visible {
+  text-decoration: underline;
+}
+
+.sort-indicator {
+  font-size: 0.7em;
+}
+
+.sticky-table-header.teal th {
+  background: #f0fdfa;
+}
+
+.sticky-table-header.red th {
+  background: #fff7ed;
+}
+
+.services-cell {
+  min-width: 300px;
+}
+
+.service-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.5rem;
+  max-width: 34rem;
+}
+
+.service-badge {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.casps-data-table {
+  table-layout: fixed;
+}
+
+.casps-data-table th,
+.casps-data-table td {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.casps-country-badge,
+.casps-authority-cell {
+  white-space: nowrap;
+}
+
+.casps-website-link {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .data-table th,
+  .data-table td {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}

--- a/styles/site.css
+++ b/styles/site.css
@@ -555,3 +555,39 @@ body {
     padding-right: 0.75rem;
   }
 }
+
+/* ============================================================
+   KPI summary cards + card animations (dashboard + intent pages)
+   Moved from index.html's inline styles so the register intent
+   pages can render the same summary cards above their tables.
+   ============================================================ */
+.card-hover {
+  transition: all 0.3s ease;
+}
+
+.card-hover:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.fade-in {
+  animation: fadeIn 0.6s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.kpi-card {
+  background: linear-gradient(135deg, var(--start-color), var(--end-color));
+}
+
+.kpi-teal { --start-color: #14b8a6; --end-color: #0f766e; }
+.kpi-blue { --start-color: #0ea5e9; --end-color: #0369a1; }
+.kpi-orange { --start-color: #f97316; --end-color: #ea580c; }
+.kpi-coral { --start-color: #f43f5e; --end-color: #e11d48; }
+.kpi-purple { --start-color: #8b5cf6; --end-color: #7c3aed; }
+.kpi-red { --start-color: #dc2626; --end-color: #b91c1c; }
+.kpi-green { --start-color: #10b981; --end-color: #059669; }
+.kpi-yellow { --start-color: #f59e0b; --end-color: #d97706; }

--- a/styles/site.css
+++ b/styles/site.css
@@ -503,11 +503,11 @@ body {
 }
 
 .sticky-table-header.teal th {
-  background: #f0fdfa;
+  background: #ccfbf1;
 }
 
 .sticky-table-header.red th {
-  background: #fff7ed;
+  background: #ffedd5;
 }
 
 .services-cell {

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -714,6 +714,10 @@ video {
   margin-top: 0.25rem;
 }
 
+.mt-10 {
+  margin-top: 2.5rem;
+}
+
 .mt-12 {
   margin-top: 3rem;
 }
@@ -736,6 +740,10 @@ video {
 
 .inline-block {
   display: inline-block;
+}
+
+.inline {
+  display: inline;
 }
 
 .flex {
@@ -832,6 +840,10 @@ video {
 
 .flex-wrap {
   flex-wrap: wrap;
+}
+
+.items-start {
+  align-items: flex-start;
 }
 
 .items-center {
@@ -1433,6 +1445,12 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
 .blur {
   --tw-blur: blur(8px);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
@@ -1705,6 +1723,10 @@ video {
 
   .md\:p-10 {
     padding: 2.5rem;
+  }
+
+  .md\:p-8 {
+    padding: 2rem;
   }
 
   .md\:text-3xl {

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -790,6 +790,10 @@ video {
   width: 100%;
 }
 
+.max-w-3xl {
+  max-width: 48rem;
+}
+
 .max-w-7xl {
   max-width: 80rem;
 }
@@ -1047,6 +1051,10 @@ video {
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
+.bg-white\/15 {
+  background-color: rgb(255 255 255 / 0.15);
+}
+
 .bg-white\/30 {
   background-color: rgb(255 255 255 / 0.3);
 }
@@ -1250,12 +1258,24 @@ video {
   font-weight: 600;
 }
 
+.uppercase {
+  text-transform: uppercase;
+}
+
 .leading-7 {
   line-height: 1.75rem;
 }
 
+.leading-relaxed {
+  line-height: 1.625;
+}
+
 .leading-tight {
   line-height: 1.25;
+}
+
+.tracking-wide {
+  letter-spacing: 0.025em;
 }
 
 .text-amber-800 {
@@ -1492,6 +1512,10 @@ video {
   background-color: rgb(15 118 110 / var(--tw-bg-opacity));
 }
 
+.hover\:bg-white\/25:hover {
+  background-color: rgb(255 255 255 / 0.25);
+}
+
 .hover\:bg-gradient-to-r:hover {
   background-image: linear-gradient(to right, var(--tw-gradient-stops));
 }
@@ -1667,20 +1691,10 @@ video {
     justify-content: space-between;
   }
 
-  .md\:gap-6 {
-    gap: 1.5rem;
-  }
-
   .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-x-reverse: 0;
     margin-right: calc(0.75rem * var(--tw-space-x-reverse));
     margin-left: calc(0.75rem * calc(1 - var(--tw-space-x-reverse)));
-  }
-
-  .md\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
-    --tw-space-y-reverse: 0;
-    margin-top: calc(0px * calc(1 - var(--tw-space-y-reverse)));
-    margin-bottom: calc(0px * var(--tw-space-y-reverse));
   }
 
   .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1691,6 +1705,11 @@ video {
 
   .md\:p-10 {
     padding: 2.5rem;
+  }
+
+  .md\:text-3xl {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
   }
 
   .md\:text-\[2\.2rem\] {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   content: [
-    './index.html',
-    './about.html',
+    './*.html',
     './assets/js/**/*.js',
     './scripts/**/*.js'
   ],

--- a/update-data.js
+++ b/update-data.js
@@ -12,6 +12,17 @@ const CASPS_DATA_FILE = path.join(DATA_DIR, 'casps.json');
 const NON_COMPLIANT_DATA_FILE = path.join(DATA_DIR, 'non-compliant.json');
 const CHANGELOG_FILE = path.join(DATA_DIR, 'changelog.json');
 const FEED_FILE = path.join(__dirname, 'feed.xml');
+const SITEMAP_FILE = path.join(__dirname, 'sitemap.xml');
+
+// Static, crawlable pages served by GitHub Pages. Entity pages are generated
+// separately; keep this list in sync when adding intent pages.
+const SITEMAP_PAGES = [
+    { loc: '/', priority: '1.0', changefreq: 'weekly' },
+    { loc: '/casp-tracker.html', priority: '0.9', changefreq: 'weekly' },
+    { loc: '/emt-tracker.html', priority: '0.9', changefreq: 'weekly' },
+    { loc: '/non-compliant-casps.html', priority: '0.9', changefreq: 'weekly' },
+    { loc: '/about.html', priority: '0.5', changefreq: 'monthly' }
+];
 
 const SITE_URL = 'https://micatracker.digital-euro-association.de';
 const CHANGELOG_MAX_ENTRIES = 50;
@@ -680,6 +691,33 @@ function writeFeed(changelog) {
     fs.writeFileSync(FEED_FILE, xml);
 }
 
+function writeSitemap(lastmodDate) {
+    // lastmodDate: a YYYY-MM-DD string; fall back to today if unavailable
+    const lastmod = /^\d{4}-\d{2}-\d{2}$/.test(lastmodDate || '')
+        ? lastmodDate
+        : new Date().toISOString().slice(0, 10);
+
+    const urls = SITEMAP_PAGES.map(page => [
+        '  <url>',
+        `    <loc>${SITE_URL}${page.loc}</loc>`,
+        `    <lastmod>${lastmod}</lastmod>`,
+        `    <changefreq>${page.changefreq}</changefreq>`,
+        `    <priority>${page.priority}</priority>`,
+        '  </url>'
+    ].join('\n'));
+
+    const xml = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        ...urls,
+        '</urlset>',
+        ''
+    ].join('\n');
+
+    fs.writeFileSync(SITEMAP_FILE, xml);
+    console.log(`🗺️  Sitemap written with ${SITEMAP_PAGES.length} pages (lastmod ${lastmod})`);
+}
+
 function updateChangelog(previousDatasets, newDatasets) {
     const changes = {};
 
@@ -883,6 +921,7 @@ async function main() {
         }
 
         updateFooterDates(emtSheetDate, caspsSheetDate);
+        writeSitemap((emtSheetDate || caspsSheetDate || '').slice(0, 10));
         logSummary(jsData, nonCompliantEntries || [], caspsEntries || []);
         console.log(`📦 Data source used: ${dataSource === 'cache' ? 'cached JSON files' : 'Sheets / CSV fetch'}`);
     } catch (error) {


### PR DESCRIPTION
## Summary

Retires the homepage hash-tab dashboard in favour of the standalone intent pages, so each register has a single canonical URL. Adds per-register summary cards, fixes sticky table headers on the intent pages, and tidies the homepage intro.

## Changes

**Architecture**
- Homepage (`index.html`) is now Overview-only (KPIs, charts, changelog). Header nav links straight to `casp-tracker.html`, `emt-tracker.html`, `non-compliant-casps.html` — one canonical URL per register.
- Removed ~870 lines of embedded table/sort/search/filter/CSV code from `index.html`; `register-view.js` is now the single renderer for all three registers.
- Added a legacy-hash shim: old `#casps` / `#details` / `#emts` / `#non-compliant` bookmarks `location.replace()` to the matching page.

**Register summary cards** (`register-view.js`)
- CASP: Total Providers, Total Countries, Non-Compliant CASPs (the last fetched from `non-compliant.json`, non-fatal).
- EMT: Total Issuers, Total Tokens, Countries.
- Non-Compliant: Flagged Entities, New This Update, Countries.
- Cards recompute from the currently filtered view (Total Providers / Countries track the CASP filter); the cross-dataset Non-Compliant count stays constant.

**Styling / layout**
- Moved `kpi-card`, `card-hover` and `fade-in` styles plus the register table CSS into `styles/site.css` so the intent pages share them.
- Fixed sticky table headers on the intent pages (shared table CSS + `ResizeObserver` tracking `--site-header-height`).
- Strengthened the sticky header background tint.
- Full-width intent-page intros (dropped `max-w-3xl`); compacted the homepage intro and removed the redundant register chip links.

## Verification
- CI green on the dev tip (`326f7a9`) and every commit in the range.
- Playwright checks: register rows render on all pages, summary counts correct, CASP cards track the filter (Austria → 10/1, "bitpanda" → 3/3, Non-Compliant stays 160), legacy hashes redirect, sticky headers pin below the site nav, no console/page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By6de8kpvKXy6mBZXQkVke

---
_Generated by [Claude Code](https://claude.ai/code/session_01By6de8kpvKXy6mBZXQkVke)_