### PR TITLE
Mobile: stacked-card register tables + control/URL polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# MiCAR Tracker — working notes
+
+## Branch workflow (dev hygiene)
+
+- All development happens on `dev`; never commit directly to `main`.
+- `main` is merged from `dev` via a pull request (creates a merge commit).
+- **Keep `dev` — do not delete it after a merge.**
+- **Do not stack new work on already-merged history.** After each `dev → main`
+  PR merges, bring `dev` back in line with `main` *before* starting new work:
+  - Preferred (no history rewrite): because the PR merge commit has the `dev`
+    tip as a parent, `dev` can fast-forward to `main`:
+    `git checkout dev && git fetch origin main && git merge --ff-only origin/main && git push origin dev`
+  - If `dev` and `main` have genuinely diverged and no fast-forward is
+    possible, reset `dev` onto `main`
+    (`git checkout dev && git reset --hard origin/main && git push --force-with-lease origin dev`)
+    — but only when `dev` carries no unmerged commits worth keeping.
+
+## Architecture
+
+- Static site: HTML + Tailwind + vanilla JS, served via GitHub Pages
+  (`CNAME` → micatracker.digital-euro-association.de).
+- Data pipeline: Google Sheets → `update-data.js` → `data/*.json`, fetched at
+  runtime by the pages. The scheduled GitHub Action refreshes the JSON.
+- `index.html` is Overview-only (KPIs, charts, changelog). Each register lives
+  on its own standalone page: `casp-tracker.html`, `emt-tracker.html`,
+  `non-compliant-casps.html`.
+- `assets/js/register-view.js` is the single renderer for all three register
+  tables (search, sort, filter, CSV/JSON export, summary cards, freshness).
+  It reads `#registerRoot[data-register]`.
+- Security invariants: `esc()` on all `innerHTML` interpolation;
+  `safeHttpUrl()` for links; non-compliant entity websites are rendered as
+  plain text, never links. CSP allows only self + Umami.

--- a/assets/js/register-view.js
+++ b/assets/js/register-view.js
@@ -383,21 +383,24 @@
   // ---- markup -----------------------------------------------------------
   function controlsHtml() {
     const filterSelects = cfg.filters
-      ? '<select id="rvCountry" aria-label="Filter by country" class="search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent"><option value="">All countries</option></select>' +
-        '<select id="rvService" aria-label="Filter by service" class="search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent"><option value="">All services</option></select>'
+      ? '<select id="rvCountry" aria-label="Filter by country" class="rv-filter search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent"><option value="">All countries</option></select>' +
+        '<select id="rvService" aria-label="Filter by service" class="rv-filter search-input px-3 py-2 rounded-lg border border-gray-300 focus:ring-2 focus:ring-teal-500 focus:border-transparent"><option value="">All services</option></select>'
       : '';
     const dlBtnColor = cfg.theme === 'red' ? 'bg-red-600 hover:bg-red-700' : 'bg-teal-600 hover:bg-teal-700';
     const jsonColor = cfg.theme === 'red' ? 'bg-red-100 text-red-800 hover:bg-red-200' : 'bg-teal-100 text-teal-800 hover:bg-teal-200';
     const ring = cfg.theme === 'red' ? 'focus:ring-red-500' : 'focus:ring-teal-500';
-    return '<div class="flex flex-wrap items-center gap-3 mb-6">' +
+    // Clear / CSV / JSON share one group so they stay on a single line
+    // (they wrap together as a unit on narrow screens). The responsive
+    // widths are handled in site.css via the rv-* marker classes rather
+    // than Tailwind sm:* utilities (which aren't in the prebuilt CSS).
+    return '<div class="rv-controls flex flex-wrap items-center gap-3 mb-6">' +
       filterSelects +
-      '<div class="relative">' +
+      '<div class="rv-search relative">' +
       '<input type="text" id="rvSearch" placeholder="' + esc(cfg.searchPlaceholder) + '" aria-label="' + esc(cfg.searchLabel) + '" class="search-input pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:ring-2 ' + ring + ' focus:border-transparent w-64">' +
       '<i class="fas fa-search absolute left-3 top-3 text-gray-400" aria-hidden="true"></i>' +
       '</div>' +
-      '<button id="rvClear" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors"><i class="fas fa-times mr-1" aria-hidden="true"></i>Clear</button>' +
-      '<div class="flex items-center gap-3">' +
-      '<span class="text-sm text-gray-500">Download:</span>' +
+      '<div class="rv-actions flex items-center gap-2">' +
+      '<button id="rvClear" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors whitespace-nowrap"><i class="fas fa-times mr-1" aria-hidden="true"></i>Clear</button>' +
       '<button id="rvCsv" class="px-3 py-2 text-sm text-white rounded-lg transition-colors whitespace-nowrap ' + dlBtnColor + '"><i class="fas fa-download mr-1" aria-hidden="true"></i>CSV</button>' +
       '<a href="' + cfg.jsonHref + '" download="' + cfg.jsonName + '" class="px-3 py-2 text-sm rounded-lg transition-colors whitespace-nowrap font-semibold ' + jsonColor + '">JSON</a>' +
       '</div></div>';

--- a/assets/js/register-view.js
+++ b/assets/js/register-view.js
@@ -152,12 +152,12 @@
           }).join('')
           : '<span class="text-xs text-gray-500">Not provided</span>';
         return '<tr class="border-b hover:bg-gradient-to-r hover:from-teal-200 hover:to-blue-200 transition-all duration-200">' +
-          '<td class="p-4 text-sm font-semibold text-gray-500">' + (i + 1) + '</td>' +
-          '<td class="p-4"><p class="text-gray-900 font-semibold">' + esc(item.name || 'N/A') + '</p></td>' +
-          '<td class="p-4"><span class="casps-country-badge px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.memberState) + '</span> ' + esc(item.memberState || 'Unknown') + '</span></td>' +
-          '<td class="p-4 text-gray-600 text-sm casps-authority-cell">' + esc(item.authority || '—') + '</td>' +
-          '<td class="p-4 services-cell"><div class="service-badges">' + (services || '<span class="text-xs text-gray-500">Not specified</span>') + '</div></td>' +
-          '<td class="p-4"><div class="space-y-1">' + sites + '</div></td></tr>';
+          '<td class="p-4 text-sm font-semibold text-gray-500 rv-index" data-label="#">' + (i + 1) + '</td>' +
+          '<td class="p-4 rv-title" data-label="CASP"><p class="text-gray-900 font-semibold">' + esc(item.name || 'N/A') + '</p></td>' +
+          '<td class="p-4" data-label="Country"><span class="casps-country-badge px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.memberState) + '</span> ' + esc(item.memberState || 'Unknown') + '</span></td>' +
+          '<td class="p-4 text-gray-600 text-sm casps-authority-cell" data-label="Authority">' + esc(item.authority || '—') + '</td>' +
+          '<td class="p-4 services-cell" data-label="Services"><div class="service-badges">' + (services || '<span class="text-xs text-gray-500">Not specified</span>') + '</div></td>' +
+          '<td class="p-4" data-label="Websites"><div class="space-y-1">' + sites + '</div></td></tr>';
       },
       csv: [
         { label: 'CASP', value: function (r) { return r.name; } },
@@ -197,12 +197,12 @@
         }).join(' ');
         const countCls = item.count > 1 ? 'bg-green-100 text-green-800' : (item.count === 1 ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-600');
         return '<tr class="border-b hover:bg-gradient-to-r hover:from-teal-200 hover:to-blue-200 transition-all duration-200 ' + (i % 2 === 0 ? 'bg-gray-50' : 'bg-white') + '">' +
-          '<td class="p-4"><div class="font-semibold text-gray-800">' + esc(item.issuer) + '</div></td>' +
-          '<td class="p-4"><span class="px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.state) + '</span> ' + esc(item.state) + '</span></td>' +
-          '<td class="p-4 text-gray-600 text-sm">' + esc(item.authority) + '</td>' +
-          '<td class="p-4"><div class="text-sm text-gray-800 font-mono">' + esc(item.tokens || 'N/A') + '</div></td>' +
-          '<td class="p-4 text-center"><span class="px-3 py-1 rounded-full text-sm font-bold ' + countCls + '">' + esc(item.count) + '</span></td>' +
-          '<td class="p-4 text-center"><div class="flex justify-center space-x-1">' + badges + '</div></td></tr>';
+          '<td class="p-4 rv-title" data-label="Issuer"><div class="font-semibold text-gray-800">' + esc(item.issuer) + '</div></td>' +
+          '<td class="p-4" data-label="Country"><span class="px-3 py-1 bg-teal-100 text-teal-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.state) + '</span> ' + esc(item.state) + '</span></td>' +
+          '<td class="p-4 text-gray-600 text-sm" data-label="Authority">' + esc(item.authority) + '</td>' +
+          '<td class="p-4" data-label="Tokens"><div class="text-sm text-gray-800 font-mono">' + esc(item.tokens || 'N/A') + '</div></td>' +
+          '<td class="p-4 text-center" data-label="Count"><span class="px-3 py-1 rounded-full text-sm font-bold ' + countCls + '">' + esc(item.count) + '</span></td>' +
+          '<td class="p-4 text-center" data-label="Currencies"><div class="flex justify-center space-x-1">' + badges + '</div></td></tr>';
       },
       csvColumns: function (all) {
         const base = [
@@ -248,12 +248,12 @@
         }).join('');
         const newBadge = item.isNew ? '<span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold text-blue-700 bg-blue-100"><i class="fas fa-star text-blue-500 mr-1" aria-hidden="true"></i>New</span>' : '';
         return '<tr class="border-b hover:bg-gradient-to-r hover:from-red-50 hover:to-orange-50 transition-all duration-200 ' + bg + '">' +
-          '<td class="p-4 text-sm font-semibold text-gray-500">' + (i + 1) + '</td>' +
-          '<td class="p-4"><div class="font-semibold text-gray-800 flex items-center"><span>' + esc(item.entity) + '</span>' + newBadge + '</div></td>' +
-          '<td class="p-4"><span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.country) + '</span> ' + esc(item.country) + '</span></td>' +
-          '<td class="p-4 text-gray-600 text-sm">' + esc(item.authority) + '</td>' +
-          '<td class="p-4"><div class="space-y-1">' + sites + '</div></td>' +
-          '<td class="p-4 text-center"><span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-bold" title="Flagged"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Flagged</span></span></td></tr>';
+          '<td class="p-4 text-sm font-semibold text-gray-500 rv-index" data-label="#">' + (i + 1) + '</td>' +
+          '<td class="p-4 rv-title" data-label="Entity"><div class="font-semibold text-gray-800 flex items-center"><span>' + esc(item.entity) + '</span>' + newBadge + '</div></td>' +
+          '<td class="p-4" data-label="Country"><span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-medium"><span aria-hidden="true">' + flag(item.country) + '</span> ' + esc(item.country) + '</span></td>' +
+          '<td class="p-4 text-gray-600 text-sm" data-label="Authority">' + esc(item.authority) + '</td>' +
+          '<td class="p-4" data-label="Websites"><div class="space-y-1">' + sites + '</div></td>' +
+          '<td class="p-4 text-center" data-label="Status"><span class="px-3 py-1 bg-red-100 text-red-800 rounded-full text-sm font-bold" title="Flagged"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i><span class="sr-only">Flagged</span></span></td></tr>';
       },
       csv: [
         { label: 'Entity', value: function (r) { return r.entity; } },

--- a/assets/js/register-view.js
+++ b/assets/js/register-view.js
@@ -399,10 +399,10 @@
       '<input type="text" id="rvSearch" placeholder="' + esc(cfg.searchPlaceholder) + '" aria-label="' + esc(cfg.searchLabel) + '" class="search-input pl-10 pr-4 py-2 rounded-lg border border-gray-300 focus:ring-2 ' + ring + ' focus:border-transparent w-64">' +
       '<i class="fas fa-search absolute left-3 top-3 text-gray-400" aria-hidden="true"></i>' +
       '</div>' +
-      '<div class="rv-actions flex items-center gap-2">' +
+      '<div class="rv-actions flex items-center gap-3">' +
       '<button id="rvClear" class="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors whitespace-nowrap"><i class="fas fa-times mr-1" aria-hidden="true"></i>Clear</button>' +
       '<button id="rvCsv" class="px-3 py-2 text-sm text-white rounded-lg transition-colors whitespace-nowrap ' + dlBtnColor + '"><i class="fas fa-download mr-1" aria-hidden="true"></i>CSV</button>' +
-      '<a href="' + cfg.jsonHref + '" download="' + cfg.jsonName + '" class="px-3 py-2 text-sm rounded-lg transition-colors whitespace-nowrap font-semibold ' + jsonColor + '">JSON</a>' +
+      '<a href="' + cfg.jsonHref + '" download="' + cfg.jsonName + '" class="px-3 py-2 text-sm rounded-lg transition-colors whitespace-nowrap font-semibold ' + jsonColor + '"><i class="fas fa-download mr-1" aria-hidden="true"></i>JSON</a>' +
       '</div></div>';
   }
 

--- a/styles/site.css
+++ b/styles/site.css
@@ -556,6 +556,119 @@ body {
   }
 }
 
+/* ------------------------------------------------------------
+   Mobile: stacked-card layout for the register tables.
+   Below 640px a 6-column table can't fit, so each row becomes a
+   labelled card (column header shown via the td's data-label).
+   ------------------------------------------------------------ */
+@media (max-width: 640px) {
+  .data-table-container {
+    overflow-x: visible;
+  }
+
+  /* Hide the column header row and column sizing; rows stack */
+  .data-table colgroup,
+  .data-table thead {
+    display: none;
+  }
+
+  .data-table,
+  .data-table tbody,
+  .data-table tr,
+  .data-table td {
+    display: block;
+    width: 100%;
+  }
+
+  /* casps table is normally fixed-layout; not relevant once stacked */
+  .casps-data-table {
+    table-layout: auto;
+  }
+
+  .data-table tr {
+    margin-bottom: 1rem;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 0.85rem;
+    overflow: hidden;
+    background: #ffffff;
+    box-shadow: 0 10px 20px -18px rgba(15, 23, 42, 0.5);
+  }
+
+  /* Row hover gradient doesn't make sense on a stacked card */
+  .data-table tbody tr:hover {
+    background: #ffffff !important;
+    background-image: none !important;
+  }
+
+  .data-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    text-align: right;
+    padding: 0.6rem 0.9rem !important;
+    border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+    overflow-wrap: anywhere;
+  }
+
+  .data-table td:last-child {
+    border-bottom: none;
+  }
+
+  /* Label from the column header, shown on the left of each cell */
+  .data-table td::before {
+    content: attr(data-label);
+    flex: 0 0 8rem;
+    text-align: left;
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: #475569;
+    white-space: nowrap;
+  }
+
+  /* Row-number cell isn't useful in the card view */
+  .data-table td.rv-index {
+    display: none;
+  }
+
+  /* Primary cell (name/entity/issuer) becomes the card header */
+  .data-table td.rv-title {
+    display: block;
+    text-align: left;
+    background: rgba(241, 245, 249, 0.75);
+    padding: 0.75rem 0.9rem !important;
+  }
+
+  .data-table td.rv-title::before {
+    content: none;
+  }
+
+  .data-table td.rv-title .font-semibold,
+  .data-table td.rv-title p {
+    font-size: 1rem;
+  }
+
+  /* Value side: let badges/links wrap to the right, not squash a column */
+  .services-cell {
+    min-width: 0;
+  }
+
+  .data-table td .service-badges {
+    justify-content: flex-end;
+    max-width: none;
+  }
+
+  .data-table td .space-y-1,
+  .data-table td > div {
+    min-width: 0;
+  }
+
+  .casps-website-link,
+  .casps-authority-cell {
+    white-space: normal;
+  }
+}
+
 /* ============================================================
    KPI summary cards + card animations (dashboard + intent pages)
    Moved from index.html's inline styles so the register intent

--- a/styles/site.css
+++ b/styles/site.css
@@ -562,6 +562,21 @@ body {
    labelled card (column header shown via the td's data-label).
    ------------------------------------------------------------ */
 @media (max-width: 640px) {
+  /* Controls: full-width search, filters share a row, and the
+     Clear / CSV / JSON group stays together on one line. */
+  .rv-controls .rv-search {
+    width: 100%;
+  }
+
+  .rv-controls .rv-search input {
+    width: 100%;
+  }
+
+  .rv-controls .rv-filter {
+    flex: 1 1 45%;
+    min-width: 0;
+  }
+
   .data-table-container {
     overflow-x: visible;
   }
@@ -666,6 +681,20 @@ body {
   .casps-website-link,
   .casps-authority-cell {
     white-space: normal;
+  }
+
+  /* Websites: give the value the full card width (label on its own line)
+     so URLs fit on a single line where they can, instead of wrapping in
+     the narrow right-hand column. Long URLs still break as a fallback. */
+  .data-table td[data-label="Websites"] {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: left;
+    gap: 0.4rem;
+  }
+
+  .data-table td[data-label="Websites"]::before {
+    flex: none;
   }
 }
 


### PR DESCRIPTION
## Summary

Makes the register intent pages (CASP / EMT / Non-Compliant) usable on mobile. Below 640px the six-column tables were unreadable (columns collided, URLs shattered vertically); they now render as stacked cards. Also tidies the table controls and adds a `CLAUDE.md`.

## Changes

**Mobile stacked-card tables** (`register-view.js`, `site.css`)
- Below 640px each table row becomes a bordered card: entity/CASP/issuer name as the card header, remaining columns as `label : value` rows (label from each cell's `data-label`). Row numbers hidden, hover gradient suppressed.
- Desktop (≥640px) is unchanged — normal table.

**Controls**
- Clear / CSV / JSON grouped so they stay on one line; removed the "Download:" label.
- On mobile the filter selects share a row and the search box is full width; desktop is a single row as before.
- Added the download icon to the JSON button to match CSV.

**Website cells**
- On mobile the Websites cell takes the full card width (label on its own line) so URLs fit on one line where they can, instead of wrapping mid-string.

**Docs**
- Added `CLAUDE.md` documenting the dev-branch hygiene (keep `dev`, never stack on merged history — fast-forward or reset onto `main` after each merge) and the site architecture.

## Note on styling approach
The committed `styles/tailwind.css` is not rebuilt in CI, so newly-referenced Tailwind utilities (`sm:*`, `gap-2`, `flex-1`, …) aren't present and silently no-op. Responsive control/layout rules therefore live in hand-authored `site.css` via `rv-*` marker classes; only build-verified Tailwind classes are used in the generated markup.

## Verification
- CI green on the dev tip (`2ac564b`).
- Playwright at 390px and 1280px: no horizontal overflow, stacked cards render on all three pages, search/filter still work (summary counts update; CASP Non-Compliant stays 160), Clear/CSV/JSON on one line with even 12px gaps and both download icons, website URLs single-line where they fit, desktop table unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By6de8kpvKXy6mBZXQkVke

---
_Generated by [Claude Code](https://claude.ai/code/session_01By6de8kpvKXy6mBZXQkVke)_