### PR TITLE
Add license to Dataset structured data (fixes GSC warning)

### DIFF
--- a/casp-tracker.html
+++ b/casp-tracker.html
@@ -28,6 +28,7 @@
       "keywords": ["CASP", "MiCA", "MiCAR", "crypto-asset service provider", "ESMA", "crypto licence"],
       "creator": { "@type": "Organization", "name": "Digital Euro Association", "url": "https://digital-euro-association.de" },
       "isBasedOn": "https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister",
+      "license": "https://www.esma.europa.eu/legal-notice",
       "distribution": [
         { "@type": "DataDownload", "encodingFormat": "application/json", "contentUrl": "https://micatracker.digital-euro-association.de/data/casps.json" }
       ]

--- a/emt-tracker.html
+++ b/emt-tracker.html
@@ -28,6 +28,7 @@
       "keywords": ["EMT", "e-money token", "MiCA", "MiCAR", "stablecoin", "ESMA"],
       "creator": { "@type": "Organization", "name": "Digital Euro Association", "url": "https://digital-euro-association.de" },
       "isBasedOn": "https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister",
+      "license": "https://www.esma.europa.eu/legal-notice",
       "distribution": [
         { "@type": "DataDownload", "encodingFormat": "application/json", "contentUrl": "https://micatracker.digital-euro-association.de/data/emts.json" }
       ]

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         "url": "https://digital-euro-association.de"
       },
       "isBasedOn": "https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister",
+      "license": "https://www.esma.europa.eu/legal-notice",
       "distribution": [
         {
           "@type": "DataDownload",

--- a/non-compliant-casps.html
+++ b/non-compliant-casps.html
@@ -28,6 +28,7 @@
       "keywords": ["non-compliant", "MiCA", "MiCAR", "crypto scam", "ESMA", "warning list"],
       "creator": { "@type": "Organization", "name": "Digital Euro Association", "url": "https://digital-euro-association.de" },
       "isBasedOn": "https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica#InterimMiCARegister",
+      "license": "https://www.esma.europa.eu/legal-notice",
       "distribution": [
         { "@type": "DataDownload", "encodingFormat": "application/json", "contentUrl": "https://micatracker.digital-euro-association.de/data/non-compliant.json" }
       ]


### PR DESCRIPTION
## Summary

Fixes the "Missing field 'license'" Data-sets structured-data issue reported by Google Search Console.

Adds `"license": "https://www.esma.europa.eu/legal-notice"` to the `Dataset` JSON-LD, reflecting that the underlying data is ESMA's public interim MiCA register. Applied to all four pages that carry a Dataset schema — `index.html`, `casp-tracker.html`, `emt-tracker.html`, `non-compliant-casps.html` — so the intent pages don't trigger the same warning later. FAQPage blocks on the intent pages are unaffected.

## Notes
- Non-critical GSC issue; it never affected Search appearance. After this deploys, use **Validate Fix** in GSC to prompt re-crawl.
- All four JSON-LD blocks validated as parseable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By6de8kpvKXy6mBZXQkVke

---
_Generated by [Claude Code](https://claude.ai/code/session_01By6de8kpvKXy6mBZXQkVke)_